### PR TITLE
fix: send images as photos (not file attachments) on Linux

### DIFF
--- a/scripts/patches/patch-fix-image-resize-canvas.js
+++ b/scripts/patches/patch-fix-image-resize-canvas.js
@@ -1,0 +1,96 @@
+const fs = require('fs-extra');
+const path = require('path');
+const logger = require('../utils/logger');
+
+const APP_DIR = path.join(__dirname, '..', '..', 'app');
+
+// The renderer's photo-resize entry point (offloads to the native "zimage"
+// resize task, see patch-fix-image-resize-linux.js for why that fails on
+// Linux) is called with either a filesystem path (drag-drop of a real file)
+// or a raw File/Blob object (clipboard paste, in-memory sources) as its
+// first argument. Passing a File object through to the Node utility-process
+// task hangs forever — Electron's structured-clone can't transfer a File
+// across that boundary ("#<File> could not be cloned"), and the renderer
+// never gets a response back.
+//
+// This patch replaces that entry point with a pure Canvas 2D resize: decode
+// via <img>, draw scaled onto a canvas, re-encode with canvas.toBlob(). It
+// handles both source types (reads the path via $zFileManager first if
+// needed), so it also fixes the Linux-only "no native resize" gap without
+// falling back to sending an unresized image (unlike the destinationPath
+// fallback in patch-fix-image-resize-linux.js, which is left in place as a
+// backstop for any other caller of the native resize path).
+async function main() {
+  const original = 'async resizeImage(t,{width:n,height:a,quality:s,format:i,destinationPath:o}){' +
+    'const r=new F.ResizeTask({payload:{src:t,width:n,height:a,quality:s,outputFormat:i,destinationPath:o}});' +
+    'De.zsymb(15,"Wa57B9",["offload resize via libvips","XuCTfw"],{src:t});' +
+    'try{const e=await r.run();' +
+    'return De.zsymb(15,"vYh1lX",["offload resize via libvips complete","UvVbd5"],{src:t}),e}' +
+    'catch(e){throw De.zsymb(21,"sriLO1",["offload resize via libvips fail","s606QH"],{src:t,error:e}),e}}';
+
+  const replacement = 'async resizeImage(t,{width:n,height:a,quality:s,format:i,destinationPath:o}){' +
+    'De.zsymb(15,"Wa57B9",["offload resize via libvips","XuCTfw"],{src:t});' +
+    'try{' +
+    'const zsrcBlob="string"==typeof t?new Blob([await window.$zFileManager.getFileArrayBuffer(t)]):t;' +
+    'const zurl=URL.createObjectURL(zsrcBlob);' +
+    'let zoutBlob;' +
+    'try{' +
+    'const zimg=await new Promise(((zres,zrej)=>{' +
+    'const zim=new Image();' +
+    'zim.onload=()=>zres(zim);' +
+    'zim.onerror=()=>zrej(new Error("canvas-resize: source image failed to decode"));' +
+    'zim.src=zurl' +
+    '}));' +
+    'const zcanvas=document.createElement("canvas");' +
+    'zcanvas.width=n;zcanvas.height=a;' +
+    'const zctx=zcanvas.getContext("2d");' +
+    'zctx.drawImage(zimg,0,0,n,a);' +
+    'zoutBlob=await new Promise((zres=>zcanvas.toBlob(zres,"jpeg"===i?"image/jpeg":"image/png",s)));' +
+    'if(!zoutBlob)throw new Error("canvas-resize: toBlob returned null")' +
+    '}finally{URL.revokeObjectURL(zurl)}' +
+    'if(o)await window.$zFileManager.writeBlobToPath(o,zoutBlob);' +
+    'return De.zsymb(15,"vYh1lX",["offload resize via libvips complete","UvVbd5"],{src:t}),o?void 0:zoutBlob}' +
+    'catch(e){throw De.zsymb(21,"sriLO1",["offload resize via libvips fail","s606QH"],{src:t,error:e}),e}}';
+
+  // pc-dist chunk filenames are content-hashed and change with every Zalo
+  // release, so scan for whichever file(s) actually contain the pattern
+  // instead of hardcoding a path.
+  const pcDistDir = path.join(APP_DIR, 'pc-dist');
+  const candidates = listJsFiles(pcDistDir);
+  let patchedCount = 0;
+
+  for (const filePath of candidates) {
+    const content = fs.readFileSync(filePath, 'utf8');
+    if (!content.includes(original)) continue;
+
+    const occurrences = content.split(original).length - 1;
+    const newContent = content.split(original).join(replacement);
+    fs.writeFileSync(filePath, newContent, 'utf8');
+    logger.dim(`Patched ${path.relative(APP_DIR, filePath)}: canvas-based resize (${occurrences} occurrence${occurrences > 1 ? 's' : ''})`);
+    patchedCount += occurrences;
+  }
+
+  if (patchedCount === 0) {
+    logger.warn('Pattern for renderer resizeImage (F.ResizeTask offload) not found in app/pc-dist, skipping canvas-resize patch (Zalo may have changed this code)');
+  }
+}
+
+function listJsFiles(dir) {
+  const results = [];
+  if (!fs.existsSync(dir)) return results;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...listJsFiles(full));
+    } else if (entry.isFile() && entry.name.endsWith('.js')) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { main };

--- a/scripts/patches/patch-fix-image-resize-linux.js
+++ b/scripts/patches/patch-fix-image-resize-linux.js
@@ -1,0 +1,51 @@
+const fs = require('fs-extra');
+const path = require('path');
+const logger = require('../utils/logger');
+
+const APP_DIR = path.join(__dirname, '..', '..', 'app');
+
+// Zalo's native photo-resize library ("zimage", app/native/nativelibs/zimage)
+// only ships prebuilt binaries for darwin_arm64/darwin_x64 (and a win32
+// build). Its platform-detection code never assigns a Linux target, so on
+// Linux the resize call always rejects with NOT_SUPPORT. The resize-handler
+// utility-process task then throws IMAGE_LOAD_FAILED ("IMG element failed
+// to load image"), which the renderer catches and silently falls back to
+// sending the photo as a generic file attachment instead of an image
+// message. This patch makes the resize task fall back to the original,
+// unresized image bytes when the native resize call fails, instead of
+// throwing — the image is still sent as a photo, just without the
+// size/quality reduction that macOS/Windows builds get from libvips.
+async function main() {
+  const mediaJsPath = path.join(APP_DIR, 'main-dist', 'utility-process-media.js');
+
+  if (!fs.existsSync(mediaJsPath)) {
+    logger.warn('utility-process-media.js not present, skipping image-resize Linux fallback patch');
+    return;
+  }
+
+  let content = fs.readFileSync(mediaJsPath, 'utf8');
+
+  const original = 'try{const t=await Y.resizeImage(c,n,r,i,"image/jpeg"===o?"jpeg":"png");' +
+    'if(null==t)throw this.logger.zsymb(21,"EFr71P",["resize fail, result is null","S8hEat"],e.payload),new q;' +
+    'if(s)try{await $.a.promises.writeFile(s,new Uint8Array(t))}catch(u){this.logger.zsymb(21,"9mlU0t",["write file fail","BGvPmN"],s,u)}}' +
+    'catch(l){throw this.logger.zsymb(21,"dtOtok",["resize fail","yytUN5"],e.payload,l),new q}';
+
+  const replacement = 'try{let t;try{t=await Y.resizeImage(c,n,r,i,"image/jpeg"===o?"jpeg":"png")}catch(zNativeErr){t=null}' +
+    'if(null==t){this.logger.zsymb(21,"ZFIX01",["native resize unavailable (no Linux build of zimage), falling back to original bytes","ZFIX01"],e.payload);t=c}' +
+    'if(s)try{await $.a.promises.writeFile(s,new Uint8Array(t))}catch(u){this.logger.zsymb(21,"9mlU0t",["write file fail","BGvPmN"],s,u)}}' +
+    'catch(l){throw this.logger.zsymb(21,"dtOtok",["resize fail","yytUN5"],e.payload,l),new q}';
+
+  if (content.includes(original)) {
+    content = content.replace(original, replacement);
+    fs.writeFileSync(mediaJsPath, content, 'utf8');
+    logger.dim('Patched utility-process-media.js: fall back to unresized bytes when native image resize is unavailable (Linux)');
+  } else {
+    logger.warn('Pattern for resize-handler not found in utility-process-media.js, skipping image-resize Linux fallback patch (Zalo may have changed this code)');
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { main };

--- a/scripts/prepare-app.js
+++ b/scripts/prepare-app.js
@@ -162,6 +162,12 @@ async function extractAppAsar() {
 
   const { main: patchDbCrossV4 } = require('./patches/patch-db-cross-v4');
   await patchDbCrossV4();
+
+  const { main: patchFixImageResizeLinux } = require('./patches/patch-fix-image-resize-linux');
+  await patchFixImageResizeLinux();
+
+  const { main: patchFixImageResizeCanvas } = require('./patches/patch-fix-image-resize-canvas');
+  await patchFixImageResizeCanvas();
 }
 
 function commandExists(command) {


### PR DESCRIPTION
## Vấn đề

Gửi ảnh trên bản Linux (kéo-thả file ảnh vào ô chat, và nhiều khả năng cả paste ảnh lớn từ clipboard) luôn tự động bị chuyển thành gửi dạng file đính kèm, kèm dialog "Gửi dưới dạng file — Có lỗi xảy ra trong quá trình xử lý ảnh." Lỗi xảy ra 100% các lần, trên nhiều máy khác nhau, không phụ thuộc nội dung/kích thước ảnh.

## Nguyên nhân gốc

Xác nhận trực tiếp qua CDP live debugging (`Debugger.setPauseOnExceptions({state:"all"})` + giả lập kéo-thả file thật qua `Input.dispatchDragEvent`) trên Ubuntu 26.04 + KDE Plasma Wayland:

1. **Thư viện resize ảnh native (`app/native/nativelibs/zimage`) không có bản build cho Linux.** `zimage/index.js` chỉ gán platform cho `darwin`/`win32`; trên Linux, `os` luôn là `null` → lệnh resize luôn reject với `NOT_SUPPORT` → tầng trên throw `IMAGE_LOAD_FAILED` ("IMG element failed to load image") → renderer catch và fallback gửi file.

2. **Lỗi thứ hai độc lập, phát hiện khi vá lớp 1:** entry point resize thực sự dùng trong luồng kéo-thả (`ye.resizeImage`, offload qua `F.ResizeTask`) nhận tham số nguồn ảnh có thể là **path string** hoặc **object File/Blob thật** tùy nguồn gọi. Khi là File/Blob (trường hợp kéo-thả), việc gửi nó qua task cho utility-process bị **treo vĩnh viễn** — Electron structured-clone không serialize được object `File` qua ranh giới IPC renderer↔utility-process (`Error: #<File> could not be cloned`), nên không bao giờ có response trả về.

## Fix

Hai patch áp dụng cùng lúc, theo đúng kiểu tìm-chuỗi-rồi-thay của các patch khác trong dự án:

- `patch-fix-image-resize-linux.js`: fallback ở phía Node (`utility-process-media.js`) — khi lệnh resize native thất bại, dùng luôn bytes ảnh gốc thay vì throw lỗi. Lớp phòng thủ cho các đường gọi resize khác chưa audit hết.
- `patch-fix-image-resize-canvas.js`: thay hẳn entry point resize chính (`ye.resizeImage`/`F.ResizeTask`) bằng resize thuần Canvas 2D (decode qua `<img>`, vẽ vào canvas đúng kích thước, `canvas.toBlob()`) — xử lý được cả 2 dạng input (path string lẫn File/Blob), không phụ thuộc thư viện native hay IPC nữa. Ảnh vẫn được nén/giảm kích thước như bản macOS/Windows, không phải gửi nguyên file gốc.

## Đã test

- Tái hiện lỗi 100% trước khi vá (dialog "Gửi dưới dạng file" mỗi lần kéo-thả ảnh thật).
- Sau khi vá: kéo-thả ảnh JPEG thật (1920×1080, 892 075 byte) → không còn lỗi/không còn treo → gửi thành công đúng dạng tin nhắn hình ảnh (badge HD, thả cảm xúc được).
- Xác nhận nén ảnh thật sự diễn ra (test cô lập từng bước: đọc file → decode → `canvas.toBlob` → 892 075 byte gốc nén còn 151 270 byte ở 800×500/quality 0.85; trong luồng thật Zalo tự tính tham số, ví dụ ghi nhận `1024×640/quality 0.9`).
- `npm run main` build thành công từ source với 2 patch mới, log xác nhận cả 2 patch được áp dụng đúng.