### PR TITLE
feat: add userscripts manager

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -31,6 +31,7 @@ zalo-for-linux/
 │       ├── patch-pasting-img.js
 │       └── patch-db-cross-v4.js
 ├── plugins/                 # Git submodules
+│   ├── userscripts/         # Userscripts manager
 │   ├── zadark/              # Dark mode extension
 │   └── zalux/               # Linux UX tweaks
 ├── nativelibs/              # Linux reimplementations of Zalo native addons

--- a/README.md
+++ b/README.md
@@ -21,6 +21,21 @@ Thanks **realdtn2** for the solution: [realdtn2/zalo-linux-2026](https://github.
 
 This project is best suited for users who need a native-feeling Zalo client on Linux and are comfortable with the technical workarounds required for full functionality.
 
+## 🧩 Userscripts manager
+
+Open **Settings → Userscripts manager** to create, paste, edit, import, delete,
+and enable or disable scripts that run inside Zalo. Tampermonkey-style metadata
+such as `@name`, `@description`, `@version`, `@match`, `@include`, and
+`@exclude` is recognized. Imported scripts may use the `.js` or `.user.js`
+extension.
+
+The compatibility layer currently provides `GM_info`, `GM_addStyle`,
+`GM_getValue`, `GM_setValue`, `GM_deleteValue`, `GM_listValues`, and
+`unsafeWindow`. Changes take effect the next time the Zalo page is loaded.
+
+> **Security:** Userscripts execute with access to the current Zalo page and
+> messages displayed in it. Only install scripts whose source you trust.
+
 ## 🌙 ZaDark Integration
 
 This project includes integrated [ZaDark](https://github.com/quaric/zadark), ZaDark is an extension that helps you enable Dark Mode, more privacy features, and additional functionality.

--- a/main.js
+++ b/main.js
@@ -26,6 +26,7 @@ let isAppQuitting = false;
 
 const zaluxPlugin = require('./plugins/zalux');
 const screenshotPlugin = require('./plugins/screenshot');
+const userscriptsPlugin = require('./plugins/userscripts');
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -162,6 +163,7 @@ app.once('ready', () => {
 // Register plugins
   zaluxPlugin.register({ app, ipcMain, BrowserWindow, appDir });
   screenshotPlugin.register({ ipcMain });
+  userscriptsPlugin.register({ app, ipcMain, BrowserWindow });
 });
 
 // ---------------------------------------------------------------------------

--- a/plugins/userscripts/index.js
+++ b/plugins/userscripts/index.js
@@ -1,0 +1,299 @@
+'use strict';
+
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+const { dialog } = require('electron');
+
+const MAX_SCRIPT_SIZE = 2 * 1024 * 1024;
+const IPC = {
+  list: 'userscripts:list',
+  save: 'userscripts:save',
+  remove: 'userscripts:remove',
+  toggle: 'userscripts:toggle',
+  importFile: 'userscripts:import-file'
+};
+
+let BrowserWindowRef;
+let mainWindow;
+let managerWindow;
+let storePath;
+
+function parseMetadata(code) {
+  const metadata = {};
+  const block = String(code).match(/\/\/\s*==UserScript==([\s\S]*?)\/\/\s*==\/UserScript==/i);
+  if (!block) return metadata;
+
+  const lines = block[1].split(/\r?\n/);
+  for (const line of lines) {
+    const match = line.match(/^\s*\/\/\s*@([\w:-]+)\s+(.+?)\s*$/);
+    if (!match) continue;
+    const key = match[1].toLowerCase();
+    const value = match[2];
+    if (metadata[key] === undefined) metadata[key] = value;
+    else if (Array.isArray(metadata[key])) metadata[key].push(value);
+    else metadata[key] = [metadata[key], value];
+  }
+  return metadata;
+}
+
+function metadataValues(metadata, key) {
+  if (metadata[key] === undefined) return [];
+  return Array.isArray(metadata[key]) ? metadata[key] : [metadata[key]];
+}
+
+function firstMetadataValue(metadata, key) {
+  return metadataValues(metadata, key)[0] || '';
+}
+
+function normalizeScript(input, existing) {
+  const code = typeof input.code === 'string' ? input.code : '';
+  if (!code.trim()) throw new Error('Nội dung userscript không được để trống.');
+  if (Buffer.byteLength(code, 'utf8') > MAX_SCRIPT_SIZE) {
+    throw new Error('Userscript không được lớn hơn 2 MB.');
+  }
+
+  const metadata = parseMetadata(code);
+  const suppliedName = typeof input.name === 'string' ? input.name.trim() : '';
+  const name = suppliedName || firstMetadataValue(metadata, 'name') ||
+    (existing && existing.name) || 'Untitled userscript';
+  if (name.length > 160) throw new Error('Tên userscript không được dài hơn 160 ký tự.');
+
+  return {
+    id: existing ? existing.id : crypto.randomBytes(16).toString('hex'),
+    name,
+    description: firstMetadataValue(metadata, 'description'),
+    version: firstMetadataValue(metadata, 'version'),
+    enabled: typeof input.enabled === 'boolean'
+      ? input.enabled
+      : (existing ? existing.enabled : true),
+    code,
+    metadata,
+    createdAt: existing ? existing.createdAt : new Date().toISOString(),
+    updatedAt: new Date().toISOString()
+  };
+}
+
+function readScripts() {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(storePath, 'utf8'));
+    return Array.isArray(parsed.scripts) ? parsed.scripts : [];
+  } catch (error) {
+    if (error.code !== 'ENOENT') console.error('Cannot read userscripts:', error);
+    return [];
+  }
+}
+
+function writeScripts(scripts) {
+  fs.mkdirSync(path.dirname(storePath), { recursive: true });
+  const temporaryPath = storePath + '.tmp';
+  fs.writeFileSync(temporaryPath, JSON.stringify({ version: 1, scripts }, null, 2), { mode: 0o600 });
+  fs.renameSync(temporaryPath, storePath);
+}
+
+function publicScript(script) {
+  return {
+    id: script.id,
+    name: script.name,
+    description: script.description,
+    version: script.version,
+    enabled: script.enabled,
+    code: script.code,
+    createdAt: script.createdAt,
+    updatedAt: script.updatedAt
+  };
+}
+
+function assertManagerSender(event) {
+  if (!managerWindow || managerWindow.isDestroyed() || event.sender !== managerWindow.webContents) {
+    throw new Error('Userscripts request was rejected.');
+  }
+}
+
+function globToRegExp(glob) {
+  const escaped = glob.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
+  return new RegExp('^' + escaped + '$');
+}
+
+function scriptMatches(script, realUrl) {
+  const metadata = script.metadata || parseMetadata(script.code);
+  // Desktop Zalo is loaded from a local file. This alias lets normal Zalo-web
+  // @match rules work for imported Tampermonkey scripts.
+  const urls = [realUrl, 'https://chat.zalo.me/'];
+  const includes = [...metadataValues(metadata, 'match'), ...metadataValues(metadata, 'include')];
+  const excludes = [...metadataValues(metadata, 'exclude-match'), ...metadataValues(metadata, 'exclude')];
+  const test = (pattern) => {
+    try {
+      if (pattern === '<all_urls>') return true;
+      if (pattern.startsWith('/') && pattern.lastIndexOf('/') > 0) {
+        const lastSlash = pattern.lastIndexOf('/');
+        const expression = new RegExp(pattern.slice(1, lastSlash), pattern.slice(lastSlash + 1));
+        return urls.some((url) => expression.test(url));
+      }
+      return urls.some((url) => globToRegExp(pattern).test(url));
+    } catch (_) { return false; }
+  };
+  if (excludes.some(test)) return false;
+  return includes.length === 0 || includes.some(test);
+}
+
+function buildExecution(script) {
+  const info = {
+    script: {
+      name: script.name,
+      version: script.version || '',
+      description: script.description || ''
+    },
+    scriptHandler: 'Zalo for Linux Userscripts',
+    version: '1.0.0'
+  };
+  const namespace = 'zalux-userscript:' + script.id + ':';
+  const sourceName = script.name.replace(/[^a-z0-9_.-]+/gi, '-').slice(0, 80) || script.id;
+
+  return `(function () {
+    const GM_info = ${JSON.stringify(info)};
+    const unsafeWindow = window;
+    const prefix = ${JSON.stringify(namespace)};
+    const GM_getValue = (key, fallback) => {
+      const value = localStorage.getItem(prefix + key);
+      if (value === null) return fallback;
+      try { return JSON.parse(value); } catch (_) { return fallback; }
+    };
+    const GM_setValue = (key, value) => localStorage.setItem(prefix + key, JSON.stringify(value));
+    const GM_deleteValue = (key) => localStorage.removeItem(prefix + key);
+    const GM_listValues = () => Object.keys(localStorage)
+      .filter((key) => key.startsWith(prefix)).map((key) => key.slice(prefix.length));
+    const GM_addStyle = (css) => {
+      const style = document.createElement('style');
+      style.textContent = css;
+      (document.head || document.documentElement).appendChild(style);
+      return style;
+    };
+    try {
+      (function (GM_info, unsafeWindow, GM_getValue, GM_setValue, GM_deleteValue, GM_listValues, GM_addStyle) {
+${script.code}
+      })(GM_info, unsafeWindow, GM_getValue, GM_setValue, GM_deleteValue, GM_listValues, GM_addStyle);
+    } catch (error) {
+      console.error('[Userscript: ${sourceName}]', error);
+    }
+  })();\n//# sourceURL=userscript://${sourceName}.user.js`;
+}
+
+function runEnabledScripts(win) {
+  if (!win || win.isDestroyed()) return;
+  const url = win.webContents.getURL();
+  if (!url.includes('/pc-dist/index.html') && !url.includes('/pc-dist/child.html')) return;
+
+  for (const script of readScripts()) {
+    if (!script.enabled || !scriptMatches(script, url)) continue;
+    win.webContents.executeJavaScript(buildExecution(script), true).catch((error) => {
+      console.error(`Userscript "${script.name}" failed:`, error);
+    });
+  }
+}
+
+function openManager() {
+  if (managerWindow && !managerWindow.isDestroyed()) {
+    managerWindow.show();
+    managerWindow.focus();
+    return;
+  }
+
+  managerWindow = new BrowserWindowRef({
+    parent: mainWindow && !mainWindow.isDestroyed() ? mainWindow : undefined,
+    width: 980,
+    height: 680,
+    minWidth: 760,
+    minHeight: 520,
+    title: 'Userscripts manager',
+    backgroundColor: '#f4f6f8',
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: false
+    }
+  });
+  managerWindow.setMenuBarVisibility(false);
+  if (managerWindow.removeMenu) managerWindow.removeMenu();
+  managerWindow.loadFile(path.join(__dirname, 'manager.html'));
+  managerWindow.on('closed', () => { managerWindow = null; });
+}
+
+function registerIpc(ipcMain) {
+  ipcMain.handle(IPC.list, (event) => {
+    assertManagerSender(event);
+    return readScripts().map(publicScript);
+  });
+  ipcMain.handle(IPC.save, (event, input) => {
+    assertManagerSender(event);
+    const scripts = readScripts();
+    const index = input.id ? scripts.findIndex((script) => script.id === input.id) : -1;
+    if (input.id && index < 0) throw new Error('Không tìm thấy userscript.');
+    const saved = normalizeScript(input, index >= 0 ? scripts[index] : null);
+    if (index >= 0) scripts[index] = saved;
+    else scripts.unshift(saved);
+    writeScripts(scripts);
+    return publicScript(saved);
+  });
+  ipcMain.handle(IPC.remove, (event, id) => {
+    assertManagerSender(event);
+    const scripts = readScripts();
+    const next = scripts.filter((script) => script.id !== id);
+    if (next.length === scripts.length) throw new Error('Không tìm thấy userscript.');
+    writeScripts(next);
+    return true;
+  });
+  ipcMain.handle(IPC.toggle, (event, id, enabled) => {
+    assertManagerSender(event);
+    const scripts = readScripts();
+    const script = scripts.find((item) => item.id === id);
+    if (!script) throw new Error('Không tìm thấy userscript.');
+    script.enabled = Boolean(enabled);
+    script.updatedAt = new Date().toISOString();
+    writeScripts(scripts);
+    return publicScript(script);
+  });
+  ipcMain.handle(IPC.importFile, async (event) => {
+    assertManagerSender(event);
+    const result = await dialog.showOpenDialog(managerWindow, {
+      title: 'Import userscript',
+      properties: ['openFile'],
+      filters: [
+        { name: 'Userscript', extensions: ['js'] },
+        { name: 'All files', extensions: ['*'] }
+      ]
+    });
+    if (result.canceled || !result.filePaths[0]) return null;
+    const stat = fs.statSync(result.filePaths[0]);
+    if (stat.size > MAX_SCRIPT_SIZE) throw new Error('Userscript không được lớn hơn 2 MB.');
+    const code = fs.readFileSync(result.filePaths[0], 'utf8');
+    const metadata = parseMetadata(code);
+    return { code, suggestedName: firstMetadataValue(metadata, 'name') || path.basename(result.filePaths[0], '.js') };
+  });
+}
+
+function register({ app, ipcMain, BrowserWindow }) {
+  BrowserWindowRef = BrowserWindow;
+  storePath = path.join(app.getPath('userData'), 'userscripts.json');
+  registerIpc(ipcMain);
+
+  app.on('browser-window-created', (_event, win) => {
+    if (!mainWindow && win.getTitle() !== 'Shared Worker') mainWindow = win;
+
+    win.on('page-title-updated', (event, title) => {
+      if (title !== 'USERSCRIPTS_MANAGER_TRIGGER') return;
+      event.preventDefault();
+      openManager();
+    });
+    win.webContents.on('dom-ready', () => {
+      const url = win.webContents.getURL();
+      if (!url.includes('/pc-dist/index.html') && !url.includes('/pc-dist/child.html')) return;
+      const menuScript = fs.readFileSync(path.join(__dirname, 'inject-menu.js'), 'utf8');
+      win.webContents.executeJavaScript(menuScript, true).catch(() => {});
+      runEnabledScripts(win);
+    });
+  });
+}
+
+module.exports = { register, parseMetadata, scriptMatches, normalizeScript, buildExecution };

--- a/plugins/userscripts/inject-menu.js
+++ b/plugins/userscripts/inject-menu.js
@@ -1,0 +1,63 @@
+(function () {
+  if (window.__zaloUserscriptsMenuInstalled) return;
+  window.__zaloUserscriptsMenuInstalled = true;
+
+  function openManager() {
+    const previousTitle = document.title;
+    document.title = 'USERSCRIPTS_MANAGER_TRIGGER';
+    setTimeout(function () { document.title = previousTitle; }, 100);
+  }
+
+  function addMenuItem() {
+    if (document.getElementById('zalo-userscripts-setting-item')) return;
+    const containers = document.querySelectorAll('#setting .setting-menu');
+    if (!containers.length) return;
+    const container = containers[containers.length - 1];
+    const reference = container.querySelector('.setting-menu__item');
+    const item = document.createElement('div');
+    item.id = 'zalo-userscripts-setting-item';
+    item.className = reference ? reference.className : 'setting-menu__item';
+    item.setAttribute('role', 'button');
+    item.setAttribute('tabindex', '0');
+    item.title = 'Quản lý userscript được inject vào Zalo';
+    item.innerHTML = '<div class="setting-menu__wrapper-content truncate">'
+      + '<div class="setting-menu__icon" style="display:flex;align-items:center;justify-content:center">'
+      + '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">'
+      + '<path d="M8 9l-3 3 3 3"/><path d="M16 9l3 3-3 3"/><path d="M14 5l-4 14"/>'
+      + '</svg></div><p class="setting-menu__name truncate">Userscripts manager</p></div>';
+    item.addEventListener('click', openManager);
+    item.addEventListener('keydown', function (event) {
+      if (event.key === 'Enter' || event.key === ' ') { event.preventDefault(); openManager(); }
+    });
+    container.appendChild(item);
+  }
+
+  addMenuItem();
+  let updateQueued = false;
+  function scheduleUpdate() {
+    if (updateQueued) return;
+    updateQueued = true;
+    requestAnimationFrame(function () {
+      updateQueued = false;
+      addMenuItem();
+    });
+  }
+  const observer = new MutationObserver(function (mutations) {
+    for (const mutation of mutations) {
+      const target = mutation.target.nodeType === 1 ? mutation.target : mutation.target.parentElement;
+      if (target && target.closest && target.closest('#setting .setting-menu')) {
+        scheduleUpdate();
+        return;
+      }
+      for (const node of mutation.addedNodes) {
+        if (node.nodeType !== 1) continue;
+        if ((node.matches && node.matches('#setting, #setting .setting-menu')) ||
+            (node.querySelector && node.querySelector('#setting .setting-menu'))) {
+          scheduleUpdate();
+          return;
+        }
+      }
+    }
+  });
+  observer.observe(document.documentElement, { childList: true, subtree: true });
+})();

--- a/plugins/userscripts/manager.css
+++ b/plugins/userscripts/manager.css
@@ -1,0 +1,78 @@
+:root {
+  color-scheme: light dark;
+  --bg: #f4f6f8;
+  --panel: #fff;
+  --border: #e3e8ee;
+  --text: #081c36;
+  --muted: #65788c;
+  --hover: #f0f5fb;
+  --primary: #0068ff;
+  --primary-hover: #0059db;
+  --danger: #d93025;
+}
+
+* { box-sizing: border-box; }
+body { margin: 0; height: 100vh; display: flex; overflow: hidden; background: var(--bg); color: var(--text); font: 14px -apple-system, BlinkMacSystemFont, "Inter", "Noto Sans", "Ubuntu", "Ubuntu Sans", "Segoe UI", sans-serif; }
+button, input, textarea { font: inherit; }
+.sidebar { width: 330px; flex: none; display: flex; flex-direction: column; background: var(--panel); border-right: 1px solid var(--border); }
+.brand { padding: 22px 20px 16px; display: flex; align-items: center; gap: 12px; }
+.brand-icon { width: 42px; height: 42px; display: grid; place-items: center; border-radius: 12px; background: #e9f2ff; color: var(--primary); font: 700 14px ui-monospace, monospace; }
+.brand h1 { margin: 0; font-size: 18px; }
+.brand p { margin: 3px 0 0; color: var(--muted); font-size: 12px; }
+.toolbar { padding: 0 20px 12px; display: flex; gap: 8px; }
+.button { border: 1px solid var(--border); border-radius: 8px; padding: 8px 13px; background: var(--panel); color: var(--text); cursor: pointer; font-weight: 600; }
+.button:hover { background: var(--hover); }
+.button.primary { border-color: var(--primary); background: var(--primary); color: #fff; }
+.button.primary:hover { background: var(--primary-hover); }
+.button.danger { border-color: #f2c9c6; color: var(--danger); }
+.search { margin: 0 20px 12px; height: 36px; padding: 0 10px; display: flex; align-items: center; gap: 8px; border: 1px solid var(--border); border-radius: 8px; background: var(--bg); color: var(--muted); }
+.search:focus-within { border-color: var(--primary); }
+.search input { min-width: 0; width: 100%; border: 0; outline: 0; background: transparent; color: var(--text); }
+.script-list { overflow: auto; padding: 0 10px 14px; }
+.script-item { width: 100%; display: flex; align-items: center; gap: 11px; padding: 11px; border: 0; border-radius: 9px; background: transparent; color: var(--text); text-align: left; cursor: pointer; }
+.script-item:hover { background: var(--hover); }
+.script-item.selected { background: #e8f2ff; }
+.script-state { width: 9px; height: 9px; flex: none; border-radius: 50%; background: #adb8c4; }
+.script-state.enabled { background: #19a55a; box-shadow: 0 0 0 3px #dff5e9; }
+.script-details { min-width: 0; flex: 1; }
+.script-title, .script-description { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.script-title { font-weight: 650; }
+.script-description { margin-top: 3px; color: var(--muted); font-size: 12px; }
+.empty-state { margin: auto 28px; display: none; flex-direction: column; align-items: center; text-align: center; color: var(--muted); gap: 8px; line-height: 1.5; }
+.empty-state.visible { display: flex; }
+.empty-state strong { color: var(--text); }
+.empty-icon, .welcome-icon { display: grid; place-items: center; border-radius: 16px; background: #e9f2ff; color: var(--primary); font-weight: 800; }
+.empty-icon { width: 54px; height: 54px; }
+.editor-pane { min-width: 0; flex: 1; display: flex; }
+.welcome { margin: auto; max-width: 500px; padding: 30px; text-align: center; color: var(--muted); }
+.welcome-icon { width: 72px; height: 72px; margin: 0 auto 18px; font: 700 22px ui-monospace, monospace; }
+.welcome h2 { color: var(--text); }
+.warning { margin-top: 26px; padding: 12px; border-radius: 8px; background: #fff7df; color: #7b5d00; font-size: 12px; }
+.editor { min-width: 0; width: 100%; display: flex; flex-direction: column; }
+.hidden { display: none !important; }
+.editor-header { padding: 18px 22px; display: flex; align-items: flex-end; gap: 20px; background: var(--panel); border-bottom: 1px solid var(--border); }
+.name-field { min-width: 0; flex: 1; }
+.name-field label { display: block; margin-bottom: 6px; color: var(--muted); font-size: 12px; font-weight: 650; }
+.name-field input { width: 100%; padding: 9px 11px; border: 1px solid var(--border); border-radius: 8px; outline: none; background: var(--bg); color: var(--text); }
+.name-field input:focus { border-color: var(--primary); }
+.toggle-label { display: flex; align-items: center; gap: 9px; cursor: pointer; }
+.toggle-label input { position: absolute; opacity: 0; }
+.toggle-label i { position: relative; width: 38px; height: 22px; border-radius: 12px; background: #aeb8c2; transition: .15s; }
+.toggle-label i::after { content: ""; position: absolute; top: 3px; left: 3px; width: 16px; height: 16px; border-radius: 50%; background: #fff; transition: .15s; }
+.toggle-label input:checked + i { background: var(--primary); }
+.toggle-label input:checked + i::after { transform: translateX(16px); }
+.editor-meta { padding: 9px 22px; border-bottom: 1px solid var(--border); color: var(--muted); font-size: 11px; }
+code { font-family: ui-monospace, SFMono-Regular, Consolas, monospace; }
+#script-code { min-height: 0; flex: 1; resize: none; border: 0; outline: 0; padding: 18px 22px; background: #111827; color: #d9e5f5; font: 13px/1.55 ui-monospace, SFMono-Regular, "JetBrainsMono Nerd Font", Hack, "Ubuntu Sans Mono", "Ubuntu Mono", "Ubuntu Monospace", Consolas, monospace; tab-size: 2; }
+.editor-footer { min-height: 62px; padding: 12px 20px; display: flex; align-items: center; gap: 18px; background: var(--panel); border-top: 1px solid var(--border); }
+.editor-footer > span { flex: 1; color: var(--muted); font-size: 11px; }
+.actions { display: flex; gap: 8px; }
+.toast { position: fixed; left: 50%; bottom: 78px; padding: 10px 15px; border-radius: 8px; background: #19324d; color: #fff; opacity: 0; pointer-events: none; transform: translate(-50%, 8px); transition: .2s; box-shadow: 0 8px 30px #0003; }
+.toast.visible { opacity: 1; transform: translate(-50%, 0); }
+.toast.error { background: #b3261e; }
+
+@media (prefers-color-scheme: dark) {
+  :root { --bg: #111923; --panel: #19232f; --border: #2c3a49; --text: #e8eef5; --muted: #94a7ba; --hover: #243447; }
+  .script-item.selected { background: #163a68; }
+  .warning { background: #3a321d; color: #e8cb70; }
+}

--- a/plugins/userscripts/manager.html
+++ b/plugins/userscripts/manager.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="vi">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self'; script-src 'self'; img-src 'self' data:">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Userscripts manager</title>
+  <link rel="stylesheet" href="manager.css">
+</head>
+<body>
+  <aside class="sidebar">
+    <div class="brand">
+      <div class="brand-icon">&lt;/&gt;</div>
+      <div><h1>Userscripts</h1><p>Inject scripts vào Zalo</p></div>
+    </div>
+    <div class="toolbar">
+      <button id="create-button" class="button primary">+ Create</button>
+      <button id="import-button" class="button">Import file</button>
+    </div>
+    <label class="search"><span>⌕</span><input id="search-input" placeholder="Tìm userscript…"></label>
+    <div id="script-list" class="script-list"></div>
+    <div id="empty-state" class="empty-state">
+      <div class="empty-icon">JS</div>
+      <strong>Chưa có userscript</strong>
+      <span>Tạo mới, paste code hoặc import file <code>.user.js</code>.</span>
+    </div>
+  </aside>
+
+  <main class="editor-pane">
+    <section id="welcome" class="welcome">
+      <div class="welcome-icon">{ }</div>
+      <h2>Userscripts manager</h2>
+      <p>Chọn một script để chỉnh sửa hoặc tạo userscript mới.</p>
+      <p class="warning">Userscript có toàn quyền truy cập nội dung Zalo. Chỉ chạy code mà bạn tin tưởng.</p>
+    </section>
+
+    <form id="editor" class="editor hidden">
+      <header class="editor-header">
+        <div class="name-field">
+          <label for="script-name">Tên userscript</label>
+          <input id="script-name" maxlength="160" required placeholder="My Zalo userscript">
+        </div>
+        <label class="toggle-label"><span>Enabled</span><input id="script-enabled" type="checkbox"><i></i></label>
+      </header>
+      <div class="editor-meta">
+        Hỗ trợ metadata Tampermonkey: <code>@name</code>, <code>@description</code>, <code>@version</code>,
+        <code>@match</code>, <code>@include</code>, <code>@exclude</code>.
+      </div>
+      <textarea id="script-code" spellcheck="false" aria-label="Userscript source code"></textarea>
+      <footer class="editor-footer">
+        <span id="status-text">Thay đổi được áp dụng từ lần tải trang Zalo tiếp theo.</span>
+        <div class="actions">
+          <button id="delete-button" type="button" class="button danger">Delete</button>
+          <button id="cancel-button" type="button" class="button">Cancel</button>
+          <button type="submit" class="button primary">Save</button>
+        </div>
+      </footer>
+    </form>
+  </main>
+
+  <div id="toast" class="toast" role="status"></div>
+  <script src="manager.js"></script>
+</body>
+</html>

--- a/plugins/userscripts/manager.js
+++ b/plugins/userscripts/manager.js
@@ -1,0 +1,177 @@
+'use strict';
+
+const STARTER = `// ==UserScript==
+// @name         New Zalo userscript
+// @namespace    zalo-for-linux
+// @version      1.0.0
+// @description  Describe what this script does
+// @match        https://chat.zalo.me/*
+// @run-at       document-idle
+// ==/UserScript==
+
+(function () {
+  'use strict';
+
+  console.log('Hello from Zalo userscript');
+})();
+`;
+
+const elements = {
+  list: document.getElementById('script-list'),
+  empty: document.getElementById('empty-state'),
+  welcome: document.getElementById('welcome'),
+  editor: document.getElementById('editor'),
+  name: document.getElementById('script-name'),
+  enabled: document.getElementById('script-enabled'),
+  code: document.getElementById('script-code'),
+  search: document.getElementById('search-input'),
+  deleteButton: document.getElementById('delete-button'),
+  toast: document.getElementById('toast')
+};
+
+let scripts = [];
+let selectedId = null;
+let toastTimer;
+
+function showToast(message, isError) {
+  clearTimeout(toastTimer);
+  elements.toast.textContent = message;
+  elements.toast.className = 'toast visible' + (isError ? ' error' : '');
+  toastTimer = setTimeout(() => { elements.toast.className = 'toast'; }, 2600);
+}
+
+function errorMessage(error) {
+  return (error && error.message ? error.message : String(error)).replace(/^Error invoking remote method '[^']+': Error:\s*/, '');
+}
+
+function renderList() {
+  const query = elements.search.value.trim().toLocaleLowerCase();
+  const filtered = scripts.filter((script) =>
+    script.name.toLocaleLowerCase().includes(query) ||
+    (script.description || '').toLocaleLowerCase().includes(query)
+  );
+  elements.list.replaceChildren();
+  elements.empty.classList.toggle('visible', scripts.length === 0);
+  elements.list.classList.toggle('hidden', scripts.length === 0);
+
+  for (const script of filtered) {
+    const item = document.createElement('button');
+    item.type = 'button';
+    item.className = 'script-item' + (script.id === selectedId ? ' selected' : '');
+    const state = document.createElement('span');
+    state.className = 'script-state' + (script.enabled ? ' enabled' : '');
+    const details = document.createElement('span');
+    details.className = 'script-details';
+    const title = document.createElement('div');
+    title.className = 'script-title';
+    title.textContent = script.name;
+    const description = document.createElement('div');
+    description.className = 'script-description';
+    description.textContent = script.description || (script.version ? 'Version ' + script.version : 'Không có mô tả');
+    details.append(title, description);
+    item.append(state, details);
+    item.addEventListener('click', () => selectScript(script.id));
+    elements.list.appendChild(item);
+  }
+}
+
+function openEditor(script) {
+  elements.welcome.classList.add('hidden');
+  elements.editor.classList.remove('hidden');
+  elements.name.value = script.name || '';
+  elements.enabled.checked = script.enabled !== false;
+  elements.code.value = script.code || '';
+  elements.deleteButton.classList.toggle('hidden', !script.id);
+  setTimeout(() => elements.name.focus(), 0);
+}
+
+function selectScript(id) {
+  const script = scripts.find((item) => item.id === id);
+  if (!script) return;
+  selectedId = id;
+  openEditor(script);
+  renderList();
+}
+
+function createScript(code = STARTER, name = 'New Zalo userscript') {
+  selectedId = null;
+  openEditor({ name, code, enabled: true });
+  renderList();
+}
+
+async function refresh(preferredId) {
+  scripts = await window.userscripts.list();
+  renderList();
+  if (preferredId && scripts.some((script) => script.id === preferredId)) selectScript(preferredId);
+}
+
+document.getElementById('create-button').addEventListener('click', () => createScript());
+document.getElementById('import-button').addEventListener('click', async () => {
+  try {
+    const imported = await window.userscripts.importFile();
+    if (imported) createScript(imported.code, imported.suggestedName);
+  } catch (error) { showToast(errorMessage(error), true); }
+});
+elements.search.addEventListener('input', renderList);
+
+elements.editor.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  try {
+    const saved = await window.userscripts.save({
+      id: selectedId,
+      name: elements.name.value,
+      enabled: elements.enabled.checked,
+      code: elements.code.value
+    });
+    selectedId = saved.id;
+    await refresh(saved.id);
+    showToast('Đã lưu. Script sẽ chạy từ lần tải trang Zalo tiếp theo.');
+  } catch (error) { showToast(errorMessage(error), true); }
+});
+
+elements.enabled.addEventListener('change', async () => {
+  if (!selectedId) return;
+  try {
+    const updated = await window.userscripts.toggle(selectedId, elements.enabled.checked);
+    const index = scripts.findIndex((script) => script.id === selectedId);
+    if (index >= 0) scripts[index] = updated;
+    renderList();
+    showToast(elements.enabled.checked ? 'Đã bật userscript.' : 'Đã tắt userscript.');
+  } catch (error) { showToast(errorMessage(error), true); }
+});
+
+elements.deleteButton.addEventListener('click', async () => {
+  if (!selectedId) return;
+  const script = scripts.find((item) => item.id === selectedId);
+  if (!confirm(`Xóa userscript “${script ? script.name : ''}”?`)) return;
+  try {
+    await window.userscripts.remove(selectedId);
+    selectedId = null;
+    elements.editor.classList.add('hidden');
+    elements.welcome.classList.remove('hidden');
+    await refresh();
+    showToast('Đã xóa userscript.');
+  } catch (error) { showToast(errorMessage(error), true); }
+});
+
+document.getElementById('cancel-button').addEventListener('click', () => {
+  if (selectedId) selectScript(selectedId);
+  else {
+    elements.editor.classList.add('hidden');
+    elements.welcome.classList.remove('hidden');
+  }
+});
+
+elements.code.addEventListener('keydown', (event) => {
+  if (event.key === 'Tab') {
+    event.preventDefault();
+    const start = elements.code.selectionStart;
+    elements.code.setRangeText('  ', start, elements.code.selectionEnd, 'end');
+  }
+  if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 's') {
+    event.preventDefault();
+    elements.editor.requestSubmit();
+  }
+});
+
+refresh().catch((error) => showToast(errorMessage(error), true));

--- a/plugins/userscripts/preload.js
+++ b/plugins/userscripts/preload.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('userscripts', {
+  list: () => ipcRenderer.invoke('userscripts:list'),
+  save: (script) => ipcRenderer.invoke('userscripts:save', script),
+  remove: (id) => ipcRenderer.invoke('userscripts:remove', id),
+  toggle: (id, enabled) => ipcRenderer.invoke('userscripts:toggle', id, enabled),
+  importFile: () => ipcRenderer.invoke('userscripts:import-file')
+});


### PR DESCRIPTION
Add userscripts manager (create, edit, toggle, import, inject scripts into Zalo).

Open **Settings → Userscripts manager** to manage scripts.\n\nSupports Tampermonkey-style metadata: \@name\, \@description\, \@version\, \@match\, \@include\, \@exclude\.\n\nGM API: \GM_info\, \GM_addStyle\, \GM_getValue\, \GM_setValue\, \GM_deleteValue\, \GM_listValues\, \unsafeWindow\.