### PR TITLE
refactor: add DE screenshot auto-detection, support set screenshot ENV support, add dms support

### DIFF
--- a/plugins/screenshot/index.js
+++ b/plugins/screenshot/index.js
@@ -9,18 +9,59 @@
 
 const { exec, execSync } = require('child_process');
 
-// Screenshot tools (in priority order)
-const SCREENSHOT_TOOLS = [
-  { name: 'cosmic-screenshot',      cmd: 'cosmic-screenshot' },
-  { name: 'deepin-screen-recorder', cmd: 'deepin-screen-recorder' },
-  { name: 'spectacle',              cmd: 'spectacle -rbc' },
-  { name: 'flameshot',              cmd: 'flameshot gui' },
-  { name: 'gnome-screenshot',       cmd: 'gnome-screenshot -ac' },
-  { name: 'xfce4-screenshooter',    cmd: 'xfce4-screenshooter -rc' },
-  { name: 'mate-screenshot',        cmd: 'mate-screenshot -i' },
-  { name: 'ksnapshot',              cmd: 'ksnapshot' },
-  { name: 'scrot',                  cmd: 'scrot' }
+function isCommandAvailable(cmd) {
+  try {
+    execSync(`command -v ${cmd}`, { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const executeCmd = (cmd) => {
+  return new Promise((resolve, reject) => {
+    exec(cmd, (err, stdout, stderr) => {
+      if (err) reject(err);
+      else resolve(stdout);
+    });
+  });
+};
+
+// DE specific tools
+const deTools = [
+  { de: 'COSMIC', name: 'cosmic-screenshot', cmd: 'cosmic-screenshot' },
+  { de: 'KDE',    name: 'spectacle',         cmd: 'spectacle -rbc' },
+  { de: 'GNOME',  name: 'gnome-screenshot',  cmd: 'gnome-screenshot -ac' },
+  { de: 'DEEPIN', name: 'deepin-screen-recorder', cmd: 'deepin-screen-recorder' },
+  { de: 'XFCE',   name: 'xfce4-screenshooter',    cmd: 'xfce4-screenshooter -rc' },
+  { de: 'MATE',   name: 'mate-screenshot',        cmd: 'mate-screenshot -i' }
 ];
+
+// Universal tools (fallback)
+const universalTools = [
+  { name: 'dms', cmd: 'dms screenshot' },
+  { name: 'ksnapshot',      cmd: 'ksnapshot' },
+  { name: 'flameshot', cmd: 'flameshot gui' },
+  { name: 'scrot',     cmd: 'scrot -s' },
+];
+
+const allTools = [...deTools, ...universalTools];
+
+// Detect the best available screenshot tool based on the current desktop environment
+function getDEScreenshotTool() {
+  const currentDesktop = (process.env.XDG_CURRENT_DESKTOP || '').toUpperCase();
+  const sessionType = (process.env.XDG_SESSION_TYPE || '').toLowerCase();
+
+  for (const item of deTools) {
+    if (currentDesktop.includes(item.de)) {
+      if (isCommandAvailable(item.name)) {
+        return item;
+      }
+    }
+  }
+
+  return null;
+}
 
 let _mainWindow = null;
 let _ipcMain    = null;
@@ -65,17 +106,50 @@ function register({ ipcMain }) {
 }
 
 function _triggerScreenshot() {
-  return new Promise((resolve) => {
-    for (const tool of SCREENSHOT_TOOLS) {
-      try {
-        execSync(`which ${tool.name}`, { stdio: 'ignore' });
-        console.log(`[Screenshot Plugin] Using ${tool.name}`);
-        exec(tool.cmd, (err) => {
-          if (err) console.error(`[Screenshot Plugin] ${tool.name} error:`, err.message);
-        });
-        setTimeout(() => resolve(true), 1500);
+  return new Promise(async (resolve) => {
+    const customToolName = (process.env.SCREENSHOT_TOOL || '').trim().toLowerCase();
+    
+    // Use set custom tool if specified in the environment variable
+    if (customToolName) {
+      const matchedTool = allTools.find(t => t.name.toLowerCase() === customToolName);
+
+      if (matchedTool) {
+        try {
+          console.log(`[Screenshot Plugin] Using custom ENV tool: ${matchedTool.name}`);
+          await executeCmd(matchedTool.cmd);
+          resolve(true);
+          return;
+        } catch (e) {
+          console.error(`[Screenshot Plugin] Custom ENV tool (${matchedTool.name}) failed: ${e.message}. Falling back...`);
+        }
+      } else {
+        console.warn(`[Screenshot Plugin] Custom tool '${customToolName}' not supported. Falling back...`);
+      }
+    }
+
+    // Try DE-specific tools first
+    try {
+      const deTool = getDEScreenshotTool();
+
+      if (deTool) {
+        console.log(`[Screenshot Plugin] Detected DE: ${process.env.XDG_CURRENT_DESKTOP || 'Unknown'} -> Using ${deTool.name}`);
+        await executeCmd(deTool.cmd);
+        resolve(true);
         return;
-      } catch (e) { /* tool not found, try next */ }
+      } else {
+        console.log('[Screenshot Plugin] No matching DE tool found, falling back to universal tools...');
+      }
+    } catch (e) { console.error(`[Screenshot Plugin] ${tool.name} failed: ${e.message}.`) /* fall back to universal tools */ } 
+    
+    // Try universal tools as a fallback
+    for (const tool of universalTools) {
+      try {
+        isCommandAvailable(tool.name);
+        console.log(`[Screenshot Plugin] Using ${tool.name}`);
+        await executeCmd(tool.cmd);
+        resolve(true);
+        return;
+      } catch (e) { console.error(`[Screenshot Plugin] ${tool.name} failed: ${e.message}.`) /* tool not found, try next */ }
     }
     console.warn('[Screenshot Plugin] No screenshot tool found');
     resolve(false);


### PR DESCRIPTION
### Fix screenshot crashes caused by calling a different screentool than the current DE or WM.
### Add DMS (DankMaterialShell) screenshot support
### Available set screenshot env (`SCREENSHOT_TOOL`):
DE default screenshot tool:
- `cosmic-screenshot` (`COSMIC`)
- `spectacle` (`KDE`)
- `gnome-screenshot`  (`GNOME`)
- `deepin-screen-recorder` (`DEEPIN`)
- `xfce4-screenshooter` (`XFCE`)
- `mate-screenshot` (`MATE`)

**Caution: Selecting the DE screenshot tool on different DE or WM may cause incompatibilities and fallbacks to auto-selection.**

Other screenshot tool:
- `dms` (DankMaterialShell's screenshot tool, `dms screenshot`)
- `ksnapshot`
- `flameshot`
- `scrot`