### PR TITLE
Về zcall và hướng xử lý trước khi zalo ra bản chính thức cho linux (đã test và hoạt động)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,8 +64,9 @@ jobs:
 
     - name: Install system build dependencies
       run: |
+        sudo dpkg --add-architecture i386
         sudo apt-get update
-        sudo apt-get install -y liblzma-dev p7zip-full gcc-mingw-w64-i686
+        sudo apt-get install -y liblzma-dev p7zip-full gcc-mingw-w64-i686 gcc gcc-multilib libx11-dev libxcb1-dev libx11-dev:i386 libxcb1-dev:i386
 
     - name: Setup and Build
       id: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,23 @@ jobs:
         name: ${{ steps.build.outputs.zadark_appimage_name }}
         path: ${{ steps.build.outputs.zadark_appimage_file }}
         retention-days: 30
-        
+
+    - name: Upload Full AppImage artifact (wine bundled, ZaDark)
+      if: steps.build.outputs.build == 'true'
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ steps.build.outputs.full_appimage_name }}
+        path: ${{ steps.build.outputs.full_appimage_file }}
+        retention-days: 30
+
+    - name: Upload Full AppImage artifact (wine bundled, no ZaDark)
+      if: steps.build.outputs.build == 'true'
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ steps.build.outputs.plainfull_appimage_name }}
+        path: ${{ steps.build.outputs.plainfull_appimage_file }}
+        retention-days: 30
+
     - name: Create Release
       if: steps.build.outputs.build == 'true'
       uses: softprops/action-gh-release@v1
@@ -102,7 +118,7 @@ jobs:
         name: ${{ steps.build.outputs.zalo_version }}
         body: |
           ## 🚀 How to use
-          
+
           It is recommended to use [Gear Lever](https://github.com/mijorus/gearlever) to manage and integrate the AppImage.
 
           ```bash
@@ -113,16 +129,22 @@ jobs:
           flatpak run it.mijorus.gearlever --integrate ${{ steps.build.outputs.zadark_appimage_name }}
           ```
 
+          > 🍷 **Full variants** (portable wine bundled inside — the call feature, voice/video/share screen, works right after the first launch with no download; larger files ~430MB):
+          > - `${{ steps.build.outputs.plainfull_appimage_name }}` (without ZaDark)
+          > - `${{ steps.build.outputs.full_appimage_name }}` (with ZaDark)
+
           ## 📋 System Requirements
           - Linux x64
           - GLIBC 2.28 or later
-          
+
           ## 🐛 Issues & Support
           Please report issues in the [GitHub Issues](https://github.com/${{ github.repository }}/issues) section.
 
         files: |
           ${{ steps.build.outputs.original_appimage_file }}
           ${{ steps.build.outputs.zadark_appimage_file }}
+          ${{ steps.build.outputs.plainfull_appimage_file }}
+          ${{ steps.build.outputs.full_appimage_file }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,9 @@ jobs:
       with:
         node-version: '22'
         cache: 'npm'
+
+    - name: Setup Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
         
     - name: Cache Electron binaries
       uses: actions/cache@v3
@@ -58,6 +61,17 @@ jobs:
         key: ${{ runner.os }}-zalo-temp-${{ hashFiles('package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-zalo-temp-
+
+    - name: Cache Cargo registry and build artifacts
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          nativelibs/*/target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('nativelibs/*/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-
           
     - name: Install Node.js dependencies
       run: npm ci --prefer-offline --no-audit
@@ -66,7 +80,7 @@ jobs:
       run: |
         sudo dpkg --add-architecture i386
         sudo apt-get update
-        sudo apt-get install -y liblzma-dev p7zip-full gcc-mingw-w64-i686 gcc gcc-multilib libc6-dev-i386 libx11-dev libxcb1-dev libx11-dev:i386 libxcb1-dev:i386
+        sudo apt-get install -y liblzma-dev p7zip-full gcc-mingw-w64-i686 gcc gcc-multilib libc6-dev-i386 libx11-dev libxcb1-dev libx11-dev:i386 libxcb1-dev:i386 libxext-dev:i386
 
     - name: Setup and Build
       id: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
       run: |
         sudo dpkg --add-architecture i386
         sudo apt-get update
-        sudo apt-get install -y liblzma-dev p7zip-full gcc-mingw-w64-i686 gcc gcc-multilib libx11-dev libxcb1-dev libx11-dev:i386 libxcb1-dev:i386
+        sudo apt-get install -y liblzma-dev p7zip-full gcc-mingw-w64-i686 gcc gcc-multilib libc6-dev-i386 libx11-dev libxcb1-dev libx11-dev:i386 libxcb1-dev:i386
 
     - name: Setup and Build
       id: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,11 @@ on:
         required: false
         default: ''
         type: string
+      zalo_win_version:
+        description: 'Zalo Windows Version for the call engine (leave empty for latest)'
+        required: false
+        default: ''
+        type: string
       zadark_version:
         description: 'ZaDark Version/Tag/Commit (leave empty for latest)'
         required: false
@@ -45,6 +50,14 @@ jobs:
         key: ${{ runner.os }}-electron-${{ hashFiles('package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-electron-
+
+    - name: Cache build downloads (DMG, Windows installer, call engine)
+      uses: actions/cache@v3
+      with:
+        path: temp
+        key: ${{ runner.os }}-zalo-temp-${{ hashFiles('package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-zalo-temp-
           
     - name: Install Node.js dependencies
       run: npm ci --prefer-offline --no-audit
@@ -52,12 +65,13 @@ jobs:
     - name: Install system build dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y liblzma-dev
+        sudo apt-get install -y liblzma-dev p7zip-full gcc-mingw-w64-i686
 
     - name: Setup and Build
       id: build
       env:
         ZALO_VERSION: ${{ github.event.inputs.zalo_version }}
+        ZALO_WIN_VERSION: ${{ github.event.inputs.zalo_win_version }}
         ZADARK_VERSION: ${{ github.event.inputs.zadark_version }}
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITHUB_REPOSITORY: ${{ github.repository }}

--- a/main.js
+++ b/main.js
@@ -28,6 +28,7 @@ const zaluxPlugin = require('./plugins/zalux');
 const screenshotPlugin = require('./plugins/screenshot');
 const launcherBadgePlugin = require('./plugins/launcher-badge');
 const userscriptsPlugin = require('./plugins/userscripts');
+const zcallBridgePlugin = require('./plugins/zcall-bridge');
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -67,6 +68,7 @@ function showMainWindow() {
 
 app.on('before-quit', () => {
   isAppQuitting = true;
+  zcallBridgePlugin.shutdown();
   if (tray) {
     tray.destroy();
     tray = null;
@@ -111,6 +113,12 @@ app.on('browser-window-created', (_evt, win) => {
           {
             label: 'Toggle DevTools',
             click: toggleDevTools
+          },
+          {
+            label: 'Cài đặt gọi điện…',
+            click: () => {
+              zcallBridgePlugin.openSetupDialog({ userDataDir: app.getPath('userData') });
+            }
           },
           {
             label: 'Thoát',
@@ -170,6 +178,7 @@ app.once('ready', () => {
   zaluxPlugin.register({ app, ipcMain, BrowserWindow, appDir });
   screenshotPlugin.register({ ipcMain });
   userscriptsPlugin.register({ app, ipcMain, BrowserWindow });
+  zcallBridgePlugin.launch({ userDataDir: app.getPath('userData') });
 });
 
 // ---------------------------------------------------------------------------

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "zalo-for-linux",
       "version": "1.0.0",
       "license": "MIT",
+      "dependencies": {
+        "fs-extra": "^11.4.0"
+      },
       "devDependencies": {
         "@electron/asar": "^4.0.1",
         "electron": "^22.3.27",
@@ -126,6 +129,21 @@
       },
       "optionalDependencies": {
         "global-agent": "^3.0.0"
+      }
+    },
+    "node_modules/@electron/get/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
       }
     },
     "node_modules/@electron/notarize": {
@@ -384,21 +402,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/@electron/universal/node_modules/fs-extra": {
-      "version": "11.3.4",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
-      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
     "node_modules/@electron/universal/node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -445,19 +448,6 @@
         "node": "*"
       }
     },
-    "node_modules/@electron/universal/node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
     "node_modules/@electron/universal/node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -472,16 +462,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@electron/universal/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/@electron/windows-sign": {
@@ -504,50 +484,6 @@
       },
       "engines": {
         "node": ">=14.14"
-      }
-    },
-    "node_modules/@electron/windows-sign/node_modules/fs-extra": {
-      "version": "11.3.4",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
-      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/@electron/windows-sign/node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@electron/windows-sign/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/@gar/promise-retry": {
@@ -3017,18 +2953,38 @@
       "license": "MIT"
     },
     "node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dev": true,
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz",
+      "integrity": "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
       },
       "engines": {
-        "node": ">=6 <7 || >=8"
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/fs-extra/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/fs-extra/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/fs-minipass": {
@@ -3245,7 +3201,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-flag": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,10 @@
           "!node_modules",
           "!package-lock.json"
         ]
+      },
+      {
+        "from": "zcall-bridge",
+        "to": "zcall-bridge"
       }
     ],
     "asarUnpack": [

--- a/package.json
+++ b/package.json
@@ -84,5 +84,8 @@
       "description": "Unofficial port of Zalo messaging application for Linux systems.",
       "icon": "app/pc-dist/favicon-512x512.png"
     }
+  },
+  "dependencies": {
+    "fs-extra": "^11.4.0"
   }
 }

--- a/plugins/screenshot/index.js
+++ b/plugins/screenshot/index.js
@@ -13,7 +13,7 @@ const { exec, execSync } = require('child_process');
 const SCREENSHOT_TOOLS = [
   { name: 'cosmic-screenshot',      cmd: 'cosmic-screenshot' },
   { name: 'deepin-screen-recorder', cmd: 'deepin-screen-recorder' },
-  { name: 'spectacle',              cmd: 'spectacle -rbc' },
+  { name: 'spectacle',              cmd: 'spectacle -rbcn' },
   { name: 'flameshot',              cmd: 'flameshot gui' },
   { name: 'gnome-screenshot',       cmd: 'gnome-screenshot -ac' },
   { name: 'xfce4-screenshooter',    cmd: 'xfce4-screenshooter -rc' },
@@ -48,9 +48,10 @@ function register({ ipcMain }) {
 
         // Restore window
         if (hideWindow && _mainWindow && !_mainWindow.isDestroyed()) {
-          _mainWindow.show();
           if (_mainWindow.isMinimized()) _mainWindow.restore();
+          _mainWindow.show();
           _mainWindow.focus();
+          _mainWindow.moveTop();
           if (!_mainWindow.webContents.isDestroyed()) {
             _mainWindow.webContents.send('show-from-tray');
           }
@@ -72,8 +73,8 @@ function _triggerScreenshot() {
         console.log(`[Screenshot Plugin] Using ${tool.name}`);
         exec(tool.cmd, (err) => {
           if (err) console.error(`[Screenshot Plugin] ${tool.name} error:`, err.message);
+          resolve(true);
         });
-        setTimeout(() => resolve(true), 1500);
         return;
       } catch (e) { /* tool not found, try next */ }
     }

--- a/plugins/zcall-bridge/index.js
+++ b/plugins/zcall-bridge/index.js
@@ -440,7 +440,10 @@ function launch({ userDataDir }) {
   const downloadedWine = findDownloadedWine(userDataDir);
   const systemWine = findWine();
   const candidates = [];
-  if (process.env.ZCALL_WINE) candidates.push(process.env.ZCALL_WINE);
+  if (process.env.ZCALL_WINE) {
+    // resolve relative paths — AppImage runs may change the working directory
+    candidates.push(path.resolve(process.env.ZCALL_WINE));
+  }
   if (downloadedWine) candidates.push(downloadedWine);
   if (systemWine && candidates.indexOf(systemWine) === -1) candidates.push(systemWine);
 

--- a/plugins/zcall-bridge/index.js
+++ b/plugins/zcall-bridge/index.js
@@ -624,13 +624,13 @@ function getI386InstallHint() {
   if (idLike.includes('arch')) {
     return {
       title: 'Cài thư viện 32-bit (Arch):',
-      command: 'sudo pacman -S --needed lib32-glibc lib32-libx11 lib32-libxext lib32-freetype2 lib32-mesa lib32-libpulse lib32-alsa-lib lib32-libv4l lib32-zlib lib32-gstreamer lib32-gst-plugins-base lib32-gst-plugins-good lib32-gst-libav\n\n(GStreamer 32-bit cần cho video call)\n\nHoặc cài wine hệ thống:\nsudo pacman -S wine'
+      command: 'sudo pacman -S --needed lib32-glibc lib32-libx11 lib32-libxext lib32-freetype2 lib32-mesa lib32-libpulse lib32-alsa-lib lib32-libv4l lib32-zlib lib32-gstreamer lib32-gst-plugins-base lib32-gst-plugins-good lib32-gst-plugins-bad lib32-gst-libav\n\n(GStreamer 32-bit cần cho video call)\n\nHoặc cài wine hệ thống:\nsudo pacman -S wine'
     };
   }
   // default: Debian/Ubuntu family
   return {
     title: 'Cài thư viện 32-bit (Ubuntu/Debian):',
-    command: 'sudo dpkg --add-architecture i386 && sudo apt update\nsudo apt install -y libc6:i386 libx11-6:i386 libfreetype6:i386 libgl1:i386 libpulse0:i386 libasound2:i386 libv4l-0:i386 zlib1g:i386 libgstreamer1.0-0:i386 libgstreamer-plugins-base1.0-0:i386 gstreamer1.0-plugins-good:i386 gstreamer1.0-libav:i386\n\n(GStreamer 32-bit cần cho video call)\n\nHoặc cài wine hệ thống (tự kéo đủ thư viện):\nsudo apt install wine'
+    command: 'sudo dpkg --add-architecture i386 && sudo apt update\nsudo apt install -y libc6:i386 libx11-6:i386 libfreetype6:i386 libgl1:i386 libpulse0:i386 libasound2:i386 libv4l-0:i386 zlib1g:i386 libgstreamer1.0-0:i386 libgstreamer-plugins-base1.0-0:i386 gstreamer1.0-plugins-good:i386 gstreamer1.0-plugins-bad:i386 gstreamer1.0-libav:i386\n\n(GStreamer 32-bit cần cho video call)\n\nHoặc cài wine hệ thống (tự kéo đủ thư viện):\nsudo apt install wine'
   };
 }
 

--- a/plugins/zcall-bridge/index.js
+++ b/plugins/zcall-bridge/index.js
@@ -112,9 +112,22 @@ function findDownloadedWine(userDataDir) {
  * PE32 binary). Runs pipebridge.exe --version (a 32-bit exe) with a timeout.
  * Returns true only when it prints the expected output.
  */
+function findPipebridgePath() {
+  const candidates = [
+    // packaged app: app/ is an extraFile next to the asar
+    path.join(process.resourcesPath || '', 'app', 'native', 'qt-call-and-cap', 'pipebridge.exe'),
+    // dev layout: repo/plugins/zcall-bridge -> repo/app/...
+    path.join(__dirname, '..', '..', 'app', 'native', 'qt-call-and-cap', 'pipebridge.exe'),
+  ];
+  for (const p of candidates) {
+    if (fs.existsSync(p)) return p;
+  }
+  return null;
+}
+
 function validateWine(winePath, prefix) {
-  const pipebridgePath = path.join(__dirname, '..', '..', 'app', 'native', 'qt-call-and-cap', 'pipebridge.exe');
-  if (!fs.existsSync(pipebridgePath)) return false;
+  const pipebridgePath = findPipebridgePath();
+  if (!pipebridgePath) return false;
   try {
     const res = spawnSync(winePath, [pipebridgePath, '--version'], {
       env: Object.assign({}, process.env, { WINEPREFIX: prefix, WINEDEBUG: '-all' }),

--- a/plugins/zcall-bridge/index.js
+++ b/plugins/zcall-bridge/index.js
@@ -9,15 +9,20 @@
  * TCP by pipebridge.exe (see app/native/qt-call-and-cap/).
  *
  * This plugin prepares the environment before any call can happen:
- *   1. Locates a wine binary: env ZCALL_WINE -> `wine` in PATH -> Bottles
- *      kron4ek runner -> previously downloaded runtime (userData).
- *   2. If no wine is found on first run, ASKS the user (friendly dialog)
- *      and downloads a portable wine (~100MB) into
- *      <userData>/zcall-wine-runtime/ with a progress window — no root
- *      needed, works on any distro.
+ *   1. Locates a wine binary, best first: env ZCALL_WINE -> user-picked
+ *      custom wine (config) -> downloaded runtime (userData) -> `wine` in
+ *      PATH -> Bottles kron4ek runner. Every candidate is validated by
+ *      actually running a 32-bit exe (pipebridge --version).
+ *   2. If no usable wine exists on first run, ASKS the user (always-on-top
+ *      window with browse/download options) and downloads a portable wine
+ *      (~54MB) into <userData>/zcall-wine-runtime/ with a progress window —
+ *      no root needed, works on any distro.
  *   3. Ensures the wine prefix exists (wineboot), exports
  *      ZCALL_WINE / ZCALL_WINEPREFIX / WINEDEBUG into process.env.
- *   4. On quit, kills the whole wine session of our prefix.
+ *   4. On quit, kills the whole wine session of our prefix; on launch,
+ *      sweeps stale wine processes of unclean previous exits.
+ *   5. Tray menu "Cài đặt gọi điện…" opens a settings window: browse/clear/
+ *      remove wine.
  *
  * Configuration (env vars):
  *   ZCALL_WINE                 wine binary (highest priority)
@@ -35,11 +40,12 @@ const os = require('os');
 const path = require('path');
 const https = require('https');
 
-// Lightest verified build (54MB download / ~565MB extracted; wine 11.x is
-// 96MB / 852MB). 8.6 chosen over 7.22/8.0.1 for a more mature wow64 while
-// keeping the same weight.
+// Recommended build: 11.14 (96MB / ~850MB). Video calls verified working on
+// it; wine 8.6 is lighter (54MB) but its msvcp140/ucrtbase lack
+// _Throw_C_error, which crashes ZaloCall when the video pipeline hits an
+// error (e.g. codec/format negotiation).
 const WINE_DOWNLOAD_URL =
-  'https://github.com/Kron4ek/Wine-Builds/releases/download/8.6/wine-8.6-amd64.tar.xz';
+  'https://github.com/Kron4ek/Wine-Builds/releases/download/11.14/wine-11.14-amd64.tar.xz';
 const RUNTIME_DIRNAME = 'zcall-wine-runtime';
 const CONFIG_FILENAME = 'zcall-config.json';
 
@@ -114,7 +120,9 @@ function findDownloadedWine(userDataDir) {
  */
 function findPipebridgePath() {
   const candidates = [
-    // packaged app: app/ is an extraFile next to the asar
+    // packaged AppImage: app/ sits at the mount root, next to the executable
+    path.join(path.dirname(process.execPath), 'app', 'native', 'qt-call-and-cap', 'pipebridge.exe'),
+    // packaged alternative: extraFiles under resources/
     path.join(process.resourcesPath || '', 'app', 'native', 'qt-call-and-cap', 'pipebridge.exe'),
     // dev layout: repo/plugins/zcall-bridge -> repo/app/...
     path.join(__dirname, '..', '..', 'app', 'native', 'qt-call-and-cap', 'pipebridge.exe'),
@@ -125,22 +133,42 @@ function findPipebridgePath() {
   return null;
 }
 
+// Console output is redirected by Zalo's own logger after bootstrap, so
+// diagnostics go to a file the user can inspect.
+function debugLog(msg) {
+  try {
+    const p = path.join(os.homedir(), '.config', 'ZaloData', 'zcall-debug.log');
+    fs.appendFileSync(p, new Date().toISOString() + ' ' + msg + '\n');
+  } catch (e) { /* ignore */ }
+}
+
 function validateWine(winePath, prefix) {
   const pipebridgePath = findPipebridgePath();
-  if (!pipebridgePath) return false;
+  if (!pipebridgePath) {
+    debugLog('validate: pipebridge.exe not found (resourcesPath=' + (process.resourcesPath || '') + ')');
+    return false;
+  }
+  // Use a dedicated throwaway prefix: validating against the real prefix can
+  // trigger slow version upgrade/downgrade passes (10-30s+) or corrupt state,
+  // and a cold first run needs a generous timeout.
+  const valPrefix = prefix + '-validate';
   try {
     const res = spawnSync(winePath, [pipebridgePath, '--version'], {
-      env: Object.assign({}, process.env, { WINEPREFIX: prefix, WINEDEBUG: '-all' }),
+      env: Object.assign({}, process.env, { WINEPREFIX: valPrefix, WINEDEBUG: '-all' }),
       encoding: 'utf8',
-      timeout: 30000
+      timeout: 120000
     });
     if (res.status === 0 && /pipebridge/.test(res.stdout || '')) return true;
-    console.error('[zcall-bridge] wine validation failed:',
-      'status=' + res.status,
-      'error=' + (res.error ? res.error.message : ''),
-      'stderr=' + String(res.stderr || '').split('\n').slice(0, 3).join(' | '));
+    debugLog('validate FAILED wine=' + winePath + ' pipebridge=' + pipebridgePath +
+      ' prefix=' + valPrefix +
+      ' status=' + res.status +
+      ' spawnError=' + (res.error ? res.error.message : '') +
+      ' stdout=' + String(res.stdout || '').slice(0, 200) +
+      ' stderr=' + String(res.stderr || '').split('\n').slice(0, 4).join(' | '));
+    console.error('[zcall-bridge] wine validation failed:', winePath, '(xem zcall-debug.log)');
     return false;
   } catch (e) {
+    debugLog('validate THREW wine=' + winePath + ' ' + e.message);
     console.error('[zcall-bridge] wine validation threw:', e.message);
     return false;
   }
@@ -152,12 +180,30 @@ function validateWine(winePath, prefix) {
  * legit session exists yet.
  */
 function sweepStaleProcesses(prefix) {
+  // Leftover helper processes from unclean previous exits (kill -9 etc.)
+  killProcessesByPattern('qt-call-and-cap');
+  killProcessesByPattern('PipeZCall');
   try {
     for (const name of ['wineserver', 'winedevice.exe']) {
       let out = '';
       try { out = execSync('pgrep -x ' + name, { encoding: 'utf8' }); } catch (_) { continue; }
       for (const pid of out.trim().split('\n')) {
         if (!pid) continue;
+
+        // winedevice is legit only when its parent is a live wineserver;
+        // orphans get reparented to systemd/init and must be killed.
+        if (name === 'winedevice.exe') {
+          let ppid = '';
+          try {
+            const stat = fs.readFileSync('/proc/' + pid + '/stat', 'utf8');
+            ppid = (stat.split(') ')[1] || '').split(' ')[1] || '';
+          } catch (_) { continue; }
+          if (parentIsWineserver(ppid)) continue; // belongs to a live wineserver
+          process.kill(Number(pid), 'SIGKILL');
+          continue;
+        }
+
+        // wineserver: match by the prefix in its environment
         let env = '';
         try { env = fs.readFileSync('/proc/' + pid + '/environ', 'utf8'); } catch (_) { continue; }
         if (env.includes(prefix)) {
@@ -264,9 +310,12 @@ function showAskWindow(failedWine) {
        không ảnh hưởng hệ thống.</p>
     <div id="url" title="Mở nguồn tải trong trình duyệt">Nguồn tải: ${downloadUrl}</div>
     <label><input type="checkbox" id="never"> Không hỏi lại lần sau nếu không tải</label>
-    <div class="row">
-      <button id="no">Để sau</button>
-      <button id="yes">Tải và bật ngay</button>
+    <div class="row" style="justify-content:space-between">
+      <button id="browse">Chọn file wine có sẵn…</button>
+      <span>
+        <button id="no">Để sau</button>
+        <button id="yes">Tải và bật ngay</button>
+      </span>
     </div>
     <script>
       const {ipcRenderer, shell} = require('electron');
@@ -278,23 +327,47 @@ function showAskWindow(failedWine) {
       }
       document.getElementById('yes').onclick = () => answer(true);
       document.getElementById('no').onclick = () => answer(false);
+      document.getElementById('browse').onclick = () => ipcRenderer.send('zcall-ask-browse');
       document.getElementById('url').onclick = () => shell.openExternal('${downloadUrl}');
     </script>
   </body></html>`;
   win.loadURL('data:text/html;charset=utf-8,' + encodeURIComponent(html));
 
   return new Promise((resolve) => {
-    const onResult = (_e, result) => {
+    let resolved = false;
+    const finish = (result) => {
+      if (resolved) return;
+      resolved = true;
       ipcMain.removeListener('zcall-ask-result', onResult);
-      try { win.close(); } catch (e) { /* already closed */ }
+      ipcMain.removeListener('zcall-ask-browse', onBrowse);
       resolve(result || { download: false, neverAgain: false });
+      // destroy AFTER resolve: destroy() emits 'closed' synchronously,
+      // which would otherwise let the fallback resolve a wrong value first
+      try { win.destroy(); } catch (e) { /* already closed */ }
+    };
+    const onResult = (_e, result) => finish(result);
+    const onBrowse = async () => {
+      const picked = await dialogModule.showOpenDialog(win, {
+        title: 'Chọn file wine',
+        properties: ['openFile']
+      });
+      const chosen = picked.filePaths && picked.filePaths[0];
+      if (!chosen) return;
+      if (validateWine(chosen, process.env.ZCALL_WINEPREFIX || path.join(os.homedir(), '.config', 'ZaloData', 'zcall-wine'))) {
+        finish({ download: false, neverAgain: false, pickedWine: chosen });
+      } else {
+        dialogModule.showMessageBox(win, {
+          type: 'error',
+          title: 'Zalo — Tính năng gọi điện',
+          message: 'Wine này không dùng được',
+          detail: 'File đã chọn không chạy được ứng dụng 32-bit hoặc không phải wine hợp lệ:\n' + chosen
+        });
+      }
     };
     ipcMain.on('zcall-ask-result', onResult);
+    ipcMain.on('zcall-ask-browse', onBrowse);
     // fallback: user closed the window somehow
-    win.on('closed', () => {
-      ipcMain.removeListener('zcall-ask-result', onResult);
-      resolve({ download: false, neverAgain: false });
-    });
+    win.on('closed', () => finish({ download: false, neverAgain: false }));
   });
 }
 
@@ -339,7 +412,7 @@ function showProgressWindow() {
       try { win.webContents.send('progress', pct, text); } catch (e) { /* window closed */ }
     },
     close() {
-      try { win.close(); } catch (e) { /* already closed */ }
+      try { win.destroy(); } catch (e) { /* already closed */ }
     }
   };
 }
@@ -358,6 +431,16 @@ async function promptAndInstall(userDataDir, failedWine) {
   }
 
   if (!result.download) {
+    // User picked an existing wine file: save it and use it.
+    if (result.pickedWine) {
+      const prefix = process.env.ZCALL_WINEPREFIX || path.join(userDataDir, 'zcall-wine');
+      writeConfig(userDataDir, { wineSetup: 'ready', winePath: result.pickedWine });
+      process.env.ZCALL_WINE = result.pickedWine;
+      process.env.ZCALL_WINEPREFIX = prefix;
+      if (!process.env.WINEDEBUG) process.env.WINEDEBUG = '-all';
+      console.log('[zcall-bridge] custom wine selected:', result.pickedWine);
+      return result.pickedWine;
+    }
     // "Để sau": ask again on next launch; ticked "không hỏi lại" -> never.
     writeConfig(userDataDir, { wineSetup: result.neverAgain ? 'declined-permanent' : 'declined' });
     return null;
@@ -365,6 +448,7 @@ async function promptAndInstall(userDataDir, failedWine) {
 
   const progress = showProgressWindow();
   try {
+    debugLog('install: starting download of portable wine');
     let lastUpdate = 0;
     const wine = await installDownloadedWine(userDataDir, (got, total) => {
       const now = Date.now();
@@ -373,6 +457,7 @@ async function promptAndInstall(userDataDir, failedWine) {
       const pct = Math.round((got / total) * 100);
       progress.set(pct, `Đang tải… ${Math.round(got / 1024 / 1024)}MB / ${Math.round(total / 1024 / 1024)}MB (${pct}%)`);
     });
+    debugLog('install: downloaded, extracting...');
     progress.set(100, 'Đang giải nén và chuẩn bị…');
 
     // First prefix init (~10-30s, done once)
@@ -395,6 +480,7 @@ async function promptAndInstall(userDataDir, failedWine) {
     }
 
     progress.close();
+    debugLog('install: SUCCESS wine=' + wine + ' prefix=' + prefix);
 
     process.env.ZCALL_WINE = wine;
     process.env.ZCALL_WINEPREFIX = prefix;
@@ -409,6 +495,7 @@ async function promptAndInstall(userDataDir, failedWine) {
     }
     return wine;
   } catch (e) {
+    debugLog('install FAILED: ' + String((e && e.message) || e) + '\n' + String((e && e.stack) || '').split('\n').slice(0, 3).join('\n'));
     progress.close();
     const parent = BrowserWindowModule.getFocusedWindow() || BrowserWindowModule.getAllWindows()[0];
     if (dialogModule) {
@@ -435,14 +522,19 @@ function launch({ userDataDir }) {
   // Clean stale wine processes from unclean previous exits
   sweepStaleProcesses(prefix);
 
-  // Candidate wines, best first: explicit env -> our portable runtime
-  // (version we control and test) -> system wine -> Bottles runners.
+  // Candidate wines, best first: explicit env -> user-picked custom wine ->
+  // our portable runtime (version we control and test) -> system wine ->
+  // Bottles runners.
   const downloadedWine = findDownloadedWine(userDataDir);
   const systemWine = findWine();
   const candidates = [];
   if (process.env.ZCALL_WINE) {
     // resolve relative paths — AppImage runs may change the working directory
     candidates.push(path.resolve(process.env.ZCALL_WINE));
+  }
+  const cfgSaved = readConfig(userDataDir);
+  if (cfgSaved.winePath && fs.existsSync(cfgSaved.winePath) && candidates.indexOf(cfgSaved.winePath) === -1) {
+    candidates.push(cfgSaved.winePath);
   }
   if (downloadedWine) candidates.push(downloadedWine);
   if (systemWine && candidates.indexOf(systemWine) === -1) candidates.push(systemWine);
@@ -479,7 +571,7 @@ function launch({ userDataDir }) {
     // Downloaded runtime exists but cannot run (machine lacks 32-bit
     // libraries): re-downloading would loop forever — guide the user
     // instead, once, without nagging every launch.
-    if (failedWine === downloadedWine) {
+    if (downloadedWine && failedWine === downloadedWine) {
       console.error('[zcall-bridge] downloaded wine broken (missing 32-bit libs?)');
       if (cfg.wineSetup !== 'broken' && process.env.ZCALL_AUTO_SETUP !== '1') {
         writeConfig(userDataDir, { wineSetup: 'broken' });
@@ -526,19 +618,19 @@ function getI386InstallHint() {
   if (idLike.includes('fedora') || idLike.includes('rhel') || idLike.includes('centos')) {
     return {
       title: 'Cài thư viện 32-bit (Fedora/RHEL):',
-      command: 'sudo dnf install -y glibc.i686 libX11.i686 libXext.i686 freetype.i686 mesa-libGL.i686 pulseaudio-libs.i686 zlib-ng-compat.i686 gstreamer1.i686 gstreamer1-plugins-base.i686 gstreamer1-plugins-good.i686 gstreamer1-plugins-bad-free.i686\n\n(GStreamer 32-bit cần cho video call; gstreamer1-plugin-libav cần RPM Fusion)\n\nHoặc cài wine hệ thống (tự kéo đủ thư viện):\nsudo dnf install wine'
+      command: 'sudo dnf install -y glibc.i686 libX11.i686 libXext.i686 freetype.i686 mesa-libGL.i686 pulseaudio-libs.i686 alsa-lib.i686 libv4l.i686 zlib-ng-compat.i686 gstreamer1.i686 gstreamer1-plugins-base.i686 gstreamer1-plugins-good.i686 gstreamer1-plugins-bad-free.i686\n\n(GStreamer 32-bit cần cho video call; gstreamer1-plugin-libav cần RPM Fusion)\n\nHoặc cài wine hệ thống (tự kéo đủ thư viện):\nsudo dnf install wine'
     };
   }
   if (idLike.includes('arch')) {
     return {
       title: 'Cài thư viện 32-bit (Arch):',
-      command: 'sudo pacman -S --needed lib32-glibc lib32-libx11 lib32-libxext lib32-freetype2 lib32-mesa lib32-libpulse lib32-zlib lib32-gstreamer lib32-gst-plugins-base lib32-gst-plugins-good lib32-gst-libav\n\n(GStreamer 32-bit cần cho video call)\n\nHoặc cài wine hệ thống:\nsudo pacman -S wine'
+      command: 'sudo pacman -S --needed lib32-glibc lib32-libx11 lib32-libxext lib32-freetype2 lib32-mesa lib32-libpulse lib32-alsa-lib lib32-libv4l lib32-zlib lib32-gstreamer lib32-gst-plugins-base lib32-gst-plugins-good lib32-gst-libav\n\n(GStreamer 32-bit cần cho video call)\n\nHoặc cài wine hệ thống:\nsudo pacman -S wine'
     };
   }
   // default: Debian/Ubuntu family
   return {
     title: 'Cài thư viện 32-bit (Ubuntu/Debian):',
-    command: 'sudo dpkg --add-architecture i386 && sudo apt update\nsudo apt install -y libc6:i386 libx11-6:i386 libfreetype6:i386 libgl1:i386 libpulse0:i386 zlib1g:i386 libgstreamer1.0-0:i386 libgstreamer-plugins-base1.0-0:i386 gstreamer1.0-plugins-good:i386 gstreamer1.0-libav:i386\n\n(GStreamer 32-bit cần cho video call)\n\nHoặc cài wine hệ thống (tự kéo đủ thư viện):\nsudo apt install wine'
+    command: 'sudo dpkg --add-architecture i386 && sudo apt update\nsudo apt install -y libc6:i386 libx11-6:i386 libfreetype6:i386 libgl1:i386 libpulse0:i386 libasound2:i386 libv4l-0:i386 zlib1g:i386 libgstreamer1.0-0:i386 libgstreamer-plugins-base1.0-0:i386 gstreamer1.0-plugins-good:i386 gstreamer1.0-libav:i386\n\n(GStreamer 32-bit cần cho video call)\n\nHoặc cài wine hệ thống (tự kéo đủ thư viện):\nsudo apt install wine'
   };
 }
 
@@ -560,69 +652,291 @@ function showBrokenWineDialog(winePath) {
 
 function openSetupDialog({ userDataDir }) {
   getElectronModules();
+  if (!BrowserWindowModule) return;
+  const { ipcMain } = require('electron');
   const prefix = process.env.ZCALL_WINEPREFIX || path.join(userDataDir, 'zcall-wine');
-  const downloadedWine = findDownloadedWine(userDataDir);
-  const wine = process.env.ZCALL_WINE || findWine() || downloadedWine;
 
-  // Downloaded runtime broken? Guide instead of re-downloading forever.
-  if (wine === downloadedWine && !validateWine(wine, prefix)) {
-    showBrokenWineDialog(downloadedWine);
-    return;
-  }
-
-  if (wine) {
-    if (dialogModule) {
-      dialogModule.showMessageBox({
-        type: 'info',
-        title: 'Zalo — Tính năng gọi điện',
-        message: 'Tính năng gọi điện đang hoạt động',
-        detail: 'Wine đang dùng: ' + wine
+  const win = new BrowserWindowModule({
+    width: 600,
+    height: 460,
+    frame: false,
+    resizable: false,
+    center: true,
+    alwaysOnTop: true,
+    webPreferences: { contextIsolation: false, nodeIntegration: true }
+  });
+  const html = `<!DOCTYPE html><html><head><meta charset="utf-8"><style>
+    body{font-family:sans-serif;background:#1f1f1f;color:#eee;margin:0;padding:20px 24px;-webkit-app-region:drag}
+    h3{margin:0 0 10px;font-size:16px}
+    #status{font-size:13px;color:#ccc;background:#2a2a2a;border-radius:6px;padding:10px 12px;margin-bottom:14px;line-height:1.5;word-break:break-all}
+    button{display:block;width:100%;font-size:13px;padding:10px;margin-bottom:10px;border-radius:6px;border:none;cursor:pointer;background:#3a3a3a;color:#eee;-webkit-app-region:no-drag}
+    button:hover{background:#4a4a4a}
+    .pathrow{display:flex;gap:8px;margin-bottom:10px;-webkit-app-region:no-drag}
+    .pathrow input{flex:1;font-size:13px;padding:9px 10px;border-radius:6px;border:1px solid #4a4a4a;background:#2a2a2a;color:#eee}
+    .pathrow button{width:auto;margin:0;white-space:nowrap}
+    #close{background:#2a2a2a}
+  </style></head><body>
+    <h3>Zalo — Cài đặt gọi điện</h3>
+    <div id="status">Đang kiểm tra…</div>
+    <div class="pathrow">
+      <input id="pathInput" placeholder="Nhập đường dẫn wine, ví dụ /usr/bin/wine">
+      <button id="setpath">Dùng đường dẫn này</button>
+    </div>
+    <button id="browse">Chọn file wine khác…</button>
+    <button id="download">Tải wine về (~54MB)</button>
+    <button id="clear">Bỏ lựa chọn wine đã lưu</button>
+    <button id="remove">Xóa wine đã tải về khỏi máy</button>
+    <button id="close">Đóng</button>
+    <script>
+      const {ipcRenderer} = require('electron');
+      // pass the command as the IPC argument so the main handler can match it
+      const send = (cmd, arg) => ipcRenderer.send(cmd, arg || cmd);
+      const closeWin = () => { send('zcall-cfg-close'); setTimeout(() => window.close(), 80); };
+      document.getElementById('browse').onclick = () => send('zcall-cfg-browse');
+      document.getElementById('download').onclick = () => send('zcall-cfg-download');
+      document.getElementById('clear').onclick = () => send('zcall-cfg-clear');
+      document.getElementById('remove').onclick = () => send('zcall-cfg-remove');
+      document.getElementById('setpath').onclick = () => send('zcall-cfg-setpath', document.getElementById('pathInput').value.trim());
+      document.getElementById('close').onclick = closeWin;
+      document.addEventListener('keydown', (e) => { if (e.key === 'Escape') closeWin(); });
+      ipcRenderer.on('zcall-cfg-status', (e, text) => {
+        document.getElementById('status').textContent = text;
       });
+    </script>
+  </body></html>`;
+  win.loadURL('data:text/html;charset=utf-8,' + encodeURIComponent(html));
+
+  const currentWine = () => process.env.ZCALL_WINE || findWine() || findDownloadedWine(userDataDir);
+  const pushStatus = () => {
+    const w = currentWine();
+    const cfg = readConfig(userDataDir);
+    let text = w
+      ? 'Wine đang dùng: ' + w + (cfg.winePath ? '\n(Lựa chọn đã lưu: ' + cfg.winePath + ')' : '')
+      : 'Chưa có wine — tính năng gọi chưa hoạt động.';
+    try { win.webContents.send('zcall-cfg-status', text); } catch (e) { /* closed */ }
+  };
+  pushStatus();
+
+  const onIpc = (_e, cmd, arg) => {
+    if (cmd === 'zcall-cfg-close') { try { win.destroy(); } catch (e) {} return; }
+    if (cmd === 'zcall-cfg-browse') {
+      dialogModule.showOpenDialog(win, { title: 'Chọn file wine', properties: ['openFile'] }).then((picked) => {
+        const chosen = picked.filePaths && picked.filePaths[0];
+        if (!chosen) return;
+        if (validateWine(chosen, prefix)) {
+          writeConfig(userDataDir, { wineSetup: 'ready', winePath: chosen });
+          process.env.ZCALL_WINE = chosen;
+          process.env.ZCALL_WINEPREFIX = prefix;
+          pushStatus();
+          new NotificationModule({ title: 'Zalo', body: 'Đã chọn wine: ' + chosen }).show();
+        } else {
+          dialogModule.showMessageBox(win, {
+            type: 'error', title: 'Zalo — Tính năng gọi điện',
+            message: 'Wine này không dùng được',
+            detail: 'File đã chọn không chạy được ứng dụng 32-bit:\n' + chosen
+          });
+        }
+      });
+      return;
     }
-    return;
-  }
-  promptAndInstall(userDataDir);
+    if (cmd === 'zcall-cfg-setpath') {
+      const typed = String(arg || '').trim();
+      if (!typed) {
+        dialogModule.showMessageBox(win, {
+          type: 'info', title: 'Zalo — Tính năng gọi điện',
+          message: 'Chưa nhập đường dẫn',
+          detail: 'Hãy nhập đường dẫn đầy đủ tới file wine, ví dụ /usr/bin/wine'
+        });
+        return;
+      }
+      if (!fs.existsSync(typed)) {
+        dialogModule.showMessageBox(win, {
+          type: 'error', title: 'Zalo — Tính năng gọi điện',
+          message: 'Không tìm thấy file',
+          detail: 'Đường dẫn không tồn tại:\n' + typed
+        });
+        return;
+      }
+      if (!validateWine(typed, prefix)) {
+        dialogModule.showMessageBox(win, {
+          type: 'error', title: 'Zalo — Tính năng gọi điện',
+          message: 'Wine này không dùng được',
+          detail: 'File không chạy được ứng dụng 32-bit hoặc không phải wine hợp lệ:\n' + typed
+        });
+        return;
+      }
+      writeConfig(userDataDir, { wineSetup: 'ready', winePath: typed });
+      process.env.ZCALL_WINE = typed;
+      process.env.ZCALL_WINEPREFIX = prefix;
+      pushStatus();
+      dialogModule.showMessageBox(win, {
+        type: 'info', title: 'Zalo — Tính năng gọi điện',
+        message: 'Đã lưu đường dẫn wine',
+        detail: typed + '\n\nLần mở app sau sẽ dùng wine này (có thể bỏ bằng nút "Bỏ lựa chọn wine đã lưu").'
+      });
+      return;
+    }
+    if (cmd === 'zcall-cfg-download') {
+      win.destroy();
+      promptAndInstall(userDataDir);
+      return;
+    }
+    if (cmd === 'zcall-cfg-clear') {
+      const cfg = readConfig(userDataDir);
+      if (cfg.winePath) {
+        delete cfg.winePath;
+        writeConfig(userDataDir, cfg);
+        pushStatus();
+        dialogModule.showMessageBox(win, {
+          type: 'info', title: 'Zalo — Tính năng gọi điện',
+          message: 'Đã bỏ lựa chọn wine đã lưu',
+          detail: 'Lần mở app sau sẽ tự dò wine lại (wine tải về → wine hệ thống).\nWine đang dùng phiên này: ' + (process.env.ZCALL_WINE || '(không có)')
+        });
+      } else {
+        dialogModule.showMessageBox(win, {
+          type: 'info', title: 'Zalo — Tính năng gọi điện',
+          message: 'Không có lựa chọn wine nào đang lưu',
+          detail: 'App đang dùng wine theo chế độ tự dò. Không có gì để bỏ.'
+        });
+      }
+      return;
+    }
+    if (cmd === 'zcall-cfg-remove') {
+      const runtime = path.join(userDataDir, RUNTIME_DIRNAME);
+      if (!fs.existsSync(runtime)) {
+        dialogModule.showMessageBox(win, {
+          type: 'info', title: 'Zalo — Tính năng gọi điện',
+          message: 'Không có wine đã tải về',
+          detail: 'Chưa có thư mục wine tải về trên máy này.'
+        });
+        return;
+      }
+      dialogModule.showMessageBox(win, {
+        type: 'warning', buttons: ['Xóa', 'Hủy'], defaultId: 1, cancelId: 1,
+        title: 'Zalo — Tính năng gọi điện',
+        message: 'Xóa wine đã tải về?',
+        detail: 'Sẽ xóa thư mục ' + runtime + '\nBạn có thể tải lại bất cứ lúc nào.'
+      }).then(({ response }) => {
+        if (response === 0) {
+          try { fs.rmSync(runtime, { recursive: true, force: true }); } catch (e) {}
+          const cfg = readConfig(userDataDir);
+          delete cfg.winePath;
+          writeConfig(userDataDir, cfg);
+          pushStatus();
+          dialogModule.showMessageBox(win, {
+            type: 'info', title: 'Zalo — Tính năng gọi điện',
+            message: 'Đã xóa wine đã tải về',
+            detail: 'Thư mục đã bị xóa. Lần mở app sau sẽ hỏi lại hoặc tự dò wine hệ thống.'
+          });
+        }
+      });
+      return;
+    }
+  };
+  const CFG_CHANNELS = ['zcall-cfg-browse', 'zcall-cfg-download', 'zcall-cfg-clear',
+                        'zcall-cfg-remove', 'zcall-cfg-close', 'zcall-cfg-setpath'];
+  for (const c of CFG_CHANNELS) ipcMain.on(c, onIpc);
+  win.on('closed', () => {
+    for (const c of CFG_CHANNELS) {
+      ipcMain.removeListener(c, onIpc);
+    }
+  });
 }
 
-function shutdown() {
-  // Kill the whole wine session for our prefix: ZaloCall.exe dies with the
-  // app (the call-v2 module kills it), but pipebridge.exe is spawned
-  // fire-and-forget and would keep wineserver alive forever. wineserver -k
-  // terminates wineserver and every wine client in this prefix.
-  const wine = process.env.ZCALL_WINE;
-  const prefix = process.env.ZCALL_WINEPREFIX;
-  if (!wine || !prefix) return;
-
-  const wineserverPath = path.join(path.dirname(wine), 'wineserver');
-  if (!fs.existsSync(wineserverPath)) return;
-
+function killProcessesByPattern(pattern) {
   try {
-    spawnSync(wineserverPath, ['-k'], {
-      env: Object.assign({}, process.env, { WINEPREFIX: prefix, WINEDEBUG: '-all' }),
-      stdio: 'ignore',
-      timeout: 10000
-    });
+    const out = execSync('pgrep -f ' + pattern, { encoding: 'utf8' });
+    for (const pid of out.trim().split('\n')) {
+      if (!pid || Number(pid) === process.pid) continue;
+      try { process.kill(Number(pid), 'SIGKILL'); } catch (_) { /* gone */ }
+    }
+  } catch (_) { /* no matches */ }
+}
+
+
+function parentIsWineserver(ppid) {
+  try {
+    return fs.readFileSync('/proc/' + ppid + '/comm', 'utf8').trim() === 'wineserver';
   } catch (e) {
-    console.error('[zcall-bridge] wineserver -k failed:', e.message);
+    return false;
+  }
+}
+
+function killWineSession(prefix) {
+  // 1. Kill the wine loader + helper processes spawned by the app. Their
+  //    cmdlines contain the engine path (dev: .../app/native/qt-call-and-cap,
+  //    packaged: /tmp/.mount_zalo*/app/native/qt-call-and-cap). pipebridge
+  //    sleeps forever and never exits on its own.
+  killProcessesByPattern('qt-call-and-cap');
+  killProcessesByPattern('PipeZCall');
+
+  // 2. Kill the wineserver serving our prefix.
+  const wine = process.env.ZCALL_WINE;
+  if (wine) {
+    const wineserverPath = path.join(path.dirname(wine), 'wineserver');
+    if (fs.existsSync(wineserverPath)) {
+      try {
+        spawnSync(wineserverPath, ['-k'], {
+          env: Object.assign({}, process.env, { WINEPREFIX: prefix, WINEDEBUG: '-all' }),
+          stdio: 'ignore',
+          timeout: 10000
+        });
+      } catch (e) {
+        console.error('[zcall-bridge] wineserver -k failed:', e.message);
+      }
+    }
   }
 
-  // Hard-kill any lingering wine processes that still serve OUR prefix (the
-  // -k above normally suffices, but during quit races a fresh server can
-  // appear or winedevice can outlive its killed server).
+  // 3. Hard-kill lingering wineserver/winedevice of our prefix.
   try {
     for (const name of ['wineserver', 'winedevice.exe']) {
       let out = '';
       try { out = execSync('pgrep -x ' + name, { encoding: 'utf8' }); } catch (_) { continue; }
       for (const pid of out.trim().split('\n')) {
         if (!pid) continue;
-        let env = '';
-        try { env = fs.readFileSync('/proc/' + pid + '/environ', 'utf8'); } catch (_) { continue; }
-        if (env.includes(prefix)) {
-          process.kill(Number(pid), 'SIGKILL');
+        if (name === 'winedevice.exe') {
+          // winedevice is legit only when its parent is a live wineserver;
+          // orphans get reparented to systemd/init and must be killed.
+          let ppid = '';
+          try {
+            const stat = fs.readFileSync('/proc/' + pid + '/stat', 'utf8');
+            ppid = (stat.split(') ')[1] || '').split(' ')[1] || '';
+          } catch (_) { continue; }
+          if (parentIsWineserver(ppid)) continue;
+        } else {
+          let env = '';
+          try { env = fs.readFileSync('/proc/' + pid + '/environ', 'utf8'); } catch (_) { continue; }
+          if (!env.includes(prefix)) continue;
         }
+        try { process.kill(Number(pid), 'SIGKILL'); } catch (_) { /* gone */ }
       }
     }
   } catch (_) { /* nothing left */ }
+
+  // 4. Second pass: the wineserver death is async — winedevice processes
+  //    whose parent just died are still orphan checkable after a short wait.
+  try { execSync('sleep 2'); } catch (_) { /* ignore */ }
+  try {
+    let out = '';
+    try { out = execSync('pgrep -x winedevice.exe', { encoding: 'utf8' }); } catch (_) { return; }
+    for (const pid of out.trim().split('\n')) {
+      if (!pid) continue;
+      let ppid = '';
+      try {
+        const stat = fs.readFileSync('/proc/' + pid + '/stat', 'utf8');
+        ppid = (stat.split(') ')[1] || '').split(' ')[1] || '';
+      } catch (_) { continue; }
+      if (!parentIsWineserver(ppid)) {
+        try { process.kill(Number(pid), 'SIGKILL'); } catch (_) { /* gone */ }
+      }
+    }
+  } catch (_) { /* nothing left */ }
+}
+
+function shutdown() {
+  const prefix = process.env.ZCALL_WINEPREFIX;
+  if (!prefix) return;
+  killWineSession(prefix);
 }
 
 module.exports = {

--- a/plugins/zcall-bridge/index.js
+++ b/plugins/zcall-bridge/index.js
@@ -1103,11 +1103,16 @@ function startScreenBridge() {
   // Missing system deps fail silently otherwise (gst then reports
   // "Could not open display" and the shim cannot reach :99).
   const missingDeps = [];
-  for (const dep of ['Xvfb', 'python3', 'xdotool']) {
+  for (const dep of ['Xvfb', 'python3', 'xdotool', 'gst-launch-1.0']) {
     try {
       const r = execSync('which ' + dep, { encoding: 'utf8' });
       if (!r.trim()) missingDeps.push(dep);
     } catch (e) { missingDeps.push(dep); }
+  }
+  for (const plugin of ['pipewiresrc', 'ximagesink']) {
+    try {
+      execSync('gst-inspect-1.0 ' + plugin, { stdio: 'ignore' });
+    } catch (e) { missingDeps.push('gst plugin ' + plugin); }
   }
   if (missingDeps.length) {
     if (dialogModule) {
@@ -1115,9 +1120,9 @@ function startScreenBridge() {
         type: 'error', title: 'Zalo — Chia sẻ màn hình',
         message: 'Thiếu thành phần hệ thống: ' + missingDeps.join(', '),
         detail: 'Cài để bật share screen:\n\n' +
-          '  Fedora:  sudo dnf install xorg-x11-server-Xvfb xdotool python3-dbus\n' +
-          '  Ubuntu:  sudo apt install xvfb xdotool python3-dbus\n' +
-          '  Arch:    sudo pacman -S xorg-server-xvfb xdotool python-dbus'
+          '  Fedora:  sudo dnf install xorg-x11-server-Xvfb xdotool python3-dbus gstreamer1-plugins-base gstreamer1-plugins-bad-free\n' +
+          '  Ubuntu:  sudo apt install xvfb xdotool python3-dbus gstreamer1.0-plugins-base gstreamer1.0-plugins-bad\n' +
+          '  Arch:    sudo pacman -S xorg-server-xvfb xdotool python-dbus gst-plugins-base gst-plugins-bad'
       });
     }
     debugLog('screenbridge: missing system deps: ' + missingDeps.join(', '));

--- a/plugins/zcall-bridge/index.js
+++ b/plugins/zcall-bridge/index.js
@@ -114,6 +114,19 @@ function findDownloadedWine(userDataDir) {
 }
 
 /**
+ * Wine bundled inside the "Full" AppImage variant (app/native/wine-runtime).
+ * In the packaged app, app/ sits at the AppImage mount root next to the
+ * executable; in dev mode it is the repo's app/ directory.
+ */
+function findBundledWine() {
+  const candidates = [
+    path.join(path.dirname(process.execPath), 'app', 'native', 'wine-runtime', 'bin', 'wine'),
+    path.join(__dirname, '..', '..', 'app', 'native', 'wine-runtime', 'bin', 'wine')
+  ];
+  return candidates.find((p) => fs.existsSync(p)) || null;
+}
+
+/**
  * Verify that this wine can actually run 32-bit executables (ZaloCall is a
  * PE32 binary). Runs pipebridge.exe --version (a 32-bit exe) with a timeout.
  * Returns true only when it prints the expected output.
@@ -131,6 +144,23 @@ function findPipebridgePath() {
     if (fs.existsSync(p)) return p;
   }
   return null;
+}
+
+/**
+ * Real filesystem path into the zcall-bridge directory. These files are
+ * spawned or LD_PRELOADed, so they must live OUTSIDE the asar archive: the
+ * package config ships zcall-bridge/ next to app/ at the AppImage mount
+ * root. Returns the packaged path when present, else the dev layout.
+ */
+function zcallBridgePath(...parts) {
+  const candidates = [
+    path.join(path.dirname(process.execPath), 'zcall-bridge', ...parts),
+    path.join(__dirname, '..', '..', 'zcall-bridge', ...parts)
+  ];
+  for (const p of candidates) {
+    if (fs.existsSync(p)) return p;
+  }
+  return candidates[1];
 }
 
 // Console output is redirected by Zalo's own logger after bootstrap, so
@@ -536,7 +566,11 @@ function launch({ userDataDir }) {
   if (cfgSaved.winePath && fs.existsSync(cfgSaved.winePath) && candidates.indexOf(cfgSaved.winePath) === -1) {
     candidates.push(cfgSaved.winePath);
   }
-  if (downloadedWine) candidates.push(downloadedWine);
+  // Bundled runtime first among the auto-discovered ones: it is paired with
+  // the exact app release (Full variant) and needs no download.
+  const bundledWine = findBundledWine();
+  if (bundledWine) candidates.push(bundledWine);
+  if (downloadedWine && candidates.indexOf(downloadedWine) === -1) candidates.push(downloadedWine);
   if (systemWine && candidates.indexOf(systemWine) === -1) candidates.push(systemWine);
 
   let wine = null;
@@ -604,7 +638,7 @@ function launch({ userDataDir }) {
   // the real display) and it signals a share request via a file, which the
   // watcher below turns into an automatic bridge start — no tray click
   // needed when the user hits "Share screen".
-  const proxySo = path.join(__dirname, '..', '..', 'zcall-bridge', 'streamproxy.so');
+  const proxySo = zcallBridgePath('streamproxy.so');
   if (fs.existsSync(proxySo)) {
     process.env.ZCALL_PROXY_SO = proxySo;
     process.env.ZCALL_PROXY_LOG = path.join(os.homedir(), '.config', 'ZaloData', 'zcall-proxy.log');
@@ -1023,7 +1057,7 @@ function startScreenBridge() {
     return true;
   }
 
-  const pyPath = path.join(__dirname, '..', '..', 'zcall-bridge', 'screenbridge.py');
+  const pyPath = zcallBridgePath('screenbridge.py');
   if (!fs.existsSync(pyPath)) {
     if (dialogModule) {
       dialogModule.showMessageBox({
@@ -1039,7 +1073,7 @@ function startScreenBridge() {
   // reads from the real display root to the bridge display, so the call UI
   // stays 100% native while "share screen" captures the bridged stream.
   // It is compiled by scripts/setup-zcall-bridge.js.
-  const proxySoPath = path.join(__dirname, '..', '..', 'zcall-bridge', 'streamproxy.so');
+  const proxySoPath = zcallBridgePath('streamproxy.so');
   if (!fs.existsSync(proxySoPath)) {
     if (dialogModule) {
       dialogModule.showMessageBox({
@@ -1066,13 +1100,39 @@ function startScreenBridge() {
   }
   const [w, h] = res.split('x');
 
+  // Missing system deps fail silently otherwise (gst then reports
+  // "Could not open display" and the shim cannot reach :99).
+  const missingDeps = [];
+  for (const dep of ['Xvfb', 'python3', 'xdotool']) {
+    try {
+      const r = execSync('which ' + dep, { encoding: 'utf8' });
+      if (!r.trim()) missingDeps.push(dep);
+    } catch (e) { missingDeps.push(dep); }
+  }
+  if (missingDeps.length) {
+    if (dialogModule) {
+      dialogModule.showMessageBox({
+        type: 'error', title: 'Zalo — Chia sẻ màn hình',
+        message: 'Thiếu thành phần hệ thống: ' + missingDeps.join(', '),
+        detail: 'Cài để bật share screen:\n\n' +
+          '  Fedora:  sudo dnf install xorg-x11-server-Xvfb xdotool python3-dbus\n' +
+          '  Ubuntu:  sudo apt install xvfb xdotool python3-dbus\n' +
+          '  Arch:    sudo pacman -S xorg-server-xvfb xdotool python-dbus'
+      });
+    }
+    debugLog('screenbridge: missing system deps: ' + missingDeps.join(', '));
+    return false;
+  }
+
   stopScreenBridge();
   bridgeGranted = false;
   try {
     // Headless Xvfb holds the bridged stream; ZaloCall keeps running on the
     // real display (native UI) and the streamproxy shim redirects its
     // screen-capture reads to this display.
-    bridgeProcs.push(spawn('Xvfb', [BRIDGE_DISPLAY, '-screen', '0', w + 'x' + h + 'x24'], { stdio: 'ignore' }));
+    const xvfb = spawn('Xvfb', [BRIDGE_DISPLAY, '-screen', '0', w + 'x' + h + 'x24'], { stdio: ['ignore', 'ignore', 'pipe'] });
+    xvfb.stderr.on('data', (d) => debugLog('screenbridge xvfb: ' + String(d).trim().slice(0, 200)));
+    bridgeProcs.push(xvfb);
     const py = spawn('python3', [pyPath, BRIDGE_DISPLAY], { stdio: ['ignore', 'ignore', 'pipe'] });
     py.stderr.on('data', (d) => {
       const s = String(d).trim().slice(0, 300);

--- a/plugins/zcall-bridge/index.js
+++ b/plugins/zcall-bridge/index.js
@@ -1,0 +1,464 @@
+/**
+ * plugins/zcall-bridge/index.js
+ *
+ * zcall call-v2 Wine environment manager.
+ *
+ * Zalo 26.x runs calls through a Qt helper (ZaloCall.exe on Windows). On
+ * Linux, the patched main-dist code (scripts/patches/patch-zcall-callv2.js)
+ * spawns the Windows ZaloCall.exe under Wine, bridged over named pipes ->
+ * TCP by pipebridge.exe (see app/native/qt-call-and-cap/).
+ *
+ * This plugin prepares the environment before any call can happen:
+ *   1. Locates a wine binary: env ZCALL_WINE -> `wine` in PATH -> Bottles
+ *      kron4ek runner -> previously downloaded runtime (userData).
+ *   2. If no wine is found on first run, ASKS the user (friendly dialog)
+ *      and downloads a portable wine (~100MB) into
+ *      <userData>/zcall-wine-runtime/ with a progress window — no root
+ *      needed, works on any distro.
+ *   3. Ensures the wine prefix exists (wineboot), exports
+ *      ZCALL_WINE / ZCALL_WINEPREFIX / WINEDEBUG into process.env.
+ *   4. On quit, kills the whole wine session of our prefix.
+ *
+ * Configuration (env vars):
+ *   ZCALL_WINE                 wine binary (highest priority)
+ *   ZCALL_WINEPREFIX           wine prefix (default: <userData>/zcall-wine)
+ *   ZCALL_DISABLE              set to anything to skip entirely
+ *   ZCALL_AUTO_SETUP           '1' to download wine silently (no dialog)
+ *   ZCALL_WINE_DOWNLOAD_URL    override the portable wine download URL
+ */
+
+'use strict';
+
+const { spawn, spawnSync, execSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const https = require('https');
+
+// Lightest verified build (54MB download / ~565MB extracted; wine 11.x is
+// 96MB / 852MB). 8.6 chosen over 7.22/8.0.1 for a more mature wow64 while
+// keeping the same weight.
+const WINE_DOWNLOAD_URL =
+  'https://github.com/Kron4ek/Wine-Builds/releases/download/8.6/wine-8.6-amd64.tar.xz';
+const RUNTIME_DIRNAME = 'zcall-wine-runtime';
+const CONFIG_FILENAME = 'zcall-config.json';
+
+let dialogModule = null;
+let BrowserWindowModule = null;
+let NotificationModule = null;
+
+function getElectronModules() {
+  try {
+    const electron = require('electron');
+    dialogModule = electron.dialog;
+    BrowserWindowModule = electron.BrowserWindow;
+    NotificationModule = electron.Notification;
+  } catch (e) { /* not running inside Electron (unit tests) */ }
+}
+
+// ---------------------------------------------------------------------------
+// Config (per-user choices, stored in userData)
+// ---------------------------------------------------------------------------
+
+function readConfig(userDataDir) {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(userDataDir, CONFIG_FILENAME), 'utf8'));
+  } catch (e) {
+    return {};
+  }
+}
+
+function writeConfig(userDataDir, cfg) {
+  try {
+    fs.mkdirSync(userDataDir, { recursive: true });
+    fs.writeFileSync(path.join(userDataDir, CONFIG_FILENAME), JSON.stringify(cfg, null, 2));
+  } catch (e) {
+    console.error('[zcall-bridge] could not write config:', e.message);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Wine discovery
+// ---------------------------------------------------------------------------
+
+function findWine() {
+  if (process.env.ZCALL_WINE) return process.env.ZCALL_WINE;
+
+  // 1. wine from PATH
+  const which = spawnSync('which', ['wine'], { encoding: 'utf8' });
+  if (which.status === 0 && which.stdout.trim()) return which.stdout.trim();
+
+  // 2. Bottles flatpak kron4ek runners (known-good on this setup)
+  const runnersRoot = path.join(os.homedir(), '.var', 'app', 'com.usebottles.bottles', 'data', 'bottles', 'runners');
+  if (fs.existsSync(runnersRoot)) {
+    const entries = fs.readdirSync(runnersRoot).sort().reverse();
+    for (const name of entries) {
+      if (!/^kron4ek-wine/.test(name)) continue;
+      const candidate = path.join(runnersRoot, name, 'bin', 'wine');
+      if (fs.existsSync(candidate)) return candidate;
+    }
+  }
+
+  return null;
+}
+
+function findDownloadedWine(userDataDir) {
+  const p = path.join(userDataDir, RUNTIME_DIRNAME, 'bin', 'wine');
+  return fs.existsSync(p) ? p : null;
+}
+
+// ---------------------------------------------------------------------------
+// Portable wine download + extract
+// ---------------------------------------------------------------------------
+
+function downloadFile(url, dest, onProgress) {
+  return new Promise((resolve, reject) => {
+    const file = fs.createWriteStream(dest);
+    https.get(url, (res) => {
+      if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+        file.close();
+        return downloadFile(res.headers.location, dest, onProgress).then(resolve, reject);
+      }
+      if (res.statusCode !== 200) {
+        file.close();
+        try { fs.unlinkSync(dest); } catch (e) { /* ignore */ }
+        reject(new Error('HTTP ' + res.statusCode));
+        return;
+      }
+      const total = parseInt(res.headers['content-length'] || '0', 10);
+      let got = 0;
+      res.on('data', (chunk) => {
+        got += chunk.length;
+        if (onProgress && total) onProgress(got, total);
+      });
+      res.pipe(file);
+      file.on('finish', () => { file.close(); resolve(); });
+    }).on('error', (e) => {
+      file.close();
+      try { fs.unlinkSync(dest); } catch (_) { /* ignore */ }
+      reject(e);
+    });
+  });
+}
+
+async function installDownloadedWine(userDataDir, onProgress) {
+  const runtimeDir = path.join(userDataDir, RUNTIME_DIRNAME);
+  const tarball = path.join(userDataDir, 'zcall-wine-download.tar.xz');
+  const url = process.env.ZCALL_WINE_DOWNLOAD_URL || WINE_DOWNLOAD_URL;
+
+  fs.mkdirSync(userDataDir, { recursive: true });
+  await downloadFile(url, tarball, onProgress);
+
+  fs.mkdirSync(runtimeDir, { recursive: true });
+  execSync(`tar -xf "${tarball}" -C "${runtimeDir}" --strip-components=1`, { stdio: 'pipe' });
+  fs.unlinkSync(tarball);
+
+  const wine = path.join(runtimeDir, 'bin', 'wine');
+  if (!fs.existsSync(wine)) throw new Error('wine binary not found after extract');
+  return wine;
+}
+
+// ---------------------------------------------------------------------------
+// Friendly setup UI (ask -> progress window -> notification)
+// ---------------------------------------------------------------------------
+
+let askWindowOpen = false;
+
+/**
+ * Custom always-on-top ask window (native dialogs can get covered by the
+ * Zalo main window on Linux DEs). Resolves with the user's choice.
+ */
+function showAskWindow() {
+  const { ipcMain } = require('electron');
+  const win = new BrowserWindowModule({
+    width: 540,
+    height: 280,
+    frame: false,
+    resizable: false,
+    movable: true,
+    center: true,
+    alwaysOnTop: true,
+    skipTaskbar: false,
+    // Tiny internal window with static HTML — node integration is safe here.
+    webPreferences: { contextIsolation: false, nodeIntegration: true }
+  });
+  const downloadUrl = process.env.ZCALL_WINE_DOWNLOAD_URL || WINE_DOWNLOAD_URL;
+  const html = `<!DOCTYPE html><html><head><meta charset="utf-8"><style>
+    body{font-family:sans-serif;background:#1f1f1f;color:#eee;margin:0;padding:20px 24px;-webkit-app-region:drag}
+    h3{margin:0 0 8px;font-size:16px}
+    p{font-size:13px;color:#ccc;margin:0 0 10px;line-height:1.45}
+    #url{font-size:11px;color:#6ab;text-overflow:ellipsis;overflow:hidden;white-space:nowrap;cursor:pointer;margin-bottom:14px;-webkit-app-region:no-drag}
+    label{font-size:13px;color:#ccc;display:block;margin-bottom:16px;-webkit-app-region:no-drag}
+    .row{display:flex;justify-content:flex-end;gap:10px;-webkit-app-region:no-drag}
+    button{font-size:13px;padding:8px 18px;border-radius:6px;border:none;cursor:pointer}
+    #yes{background:#0a6e3c;color:#fff}
+    #no{background:#3a3a3a;color:#eee}
+  </style></head><body>
+    <h3>Zalo — Tính năng gọi điện</h3>
+    <p>Tính năng gọi điện cần Wine. Tải và bật ngay bây giờ?<br>
+       Sẽ tải ~54MB về lưu trong dữ liệu của Zalo — không cần quyền quản trị,
+       không ảnh hưởng hệ thống.</p>
+    <div id="url" title="Mở nguồn tải trong trình duyệt">Nguồn tải: ${downloadUrl}</div>
+    <label><input type="checkbox" id="never"> Không hỏi lại lần sau nếu không tải</label>
+    <div class="row">
+      <button id="no">Để sau</button>
+      <button id="yes">Tải và bật ngay</button>
+    </div>
+    <script>
+      const {ipcRenderer, shell} = require('electron');
+      function answer(download) {
+        ipcRenderer.send('zcall-ask-result', {
+          download,
+          neverAgain: document.getElementById('never').checked
+        });
+      }
+      document.getElementById('yes').onclick = () => answer(true);
+      document.getElementById('no').onclick = () => answer(false);
+      document.getElementById('url').onclick = () => shell.openExternal('${downloadUrl}');
+    </script>
+  </body></html>`;
+  win.loadURL('data:text/html;charset=utf-8,' + encodeURIComponent(html));
+
+  return new Promise((resolve) => {
+    const onResult = (_e, result) => {
+      ipcMain.removeListener('zcall-ask-result', onResult);
+      try { win.close(); } catch (e) { /* already closed */ }
+      resolve(result || { download: false, neverAgain: false });
+    };
+    ipcMain.on('zcall-ask-result', onResult);
+    // fallback: user closed the window somehow
+    win.on('closed', () => {
+      ipcMain.removeListener('zcall-ask-result', onResult);
+      resolve({ download: false, neverAgain: false });
+    });
+  });
+}
+
+function showProgressWindow() {
+  const win = new BrowserWindowModule({
+    width: 520,
+    height: 165,
+    frame: false,
+    resizable: false,
+    movable: true,
+    alwaysOnTop: true,
+    // Tiny internal window with static HTML — node integration is safe here.
+    webPreferences: { contextIsolation: false, nodeIntegration: true }
+  });
+  const downloadUrl = process.env.ZCALL_WINE_DOWNLOAD_URL || WINE_DOWNLOAD_URL;
+  const html = `<!DOCTYPE html><html><head><meta charset="utf-8"><style>
+    body{font-family:sans-serif;background:#1f1f1f;color:#eee;margin:0;padding:18px 22px;-webkit-app-region:drag}
+    h3{margin:0 0 6px;font-size:15px} p{margin:0 0 12px;font-size:12px;color:#aaa}
+    progress{width:100%;height:14px}
+    #label{font-size:12px;color:#aaa;margin-top:8px}
+    #url{font-size:11px;color:#6ab;margin-top:8px;text-overflow:ellipsis;overflow:hidden;white-space:nowrap;cursor:pointer}
+  </style></head><body>
+    <h3>Zalo — Tính năng gọi điện</h3>
+    <p>Đang tải Wine (~54MB), vui lòng chờ…</p>
+    <progress id="bar" max="100" value="0"></progress>
+    <div id="label">0%</div>
+    <div id="url" title="Mở nguồn tải trong trình duyệt">${downloadUrl}</div>
+    <script>
+      const {ipcRenderer, shell} = require('electron');
+      ipcRenderer.on('progress', (e, pct, text) => {
+        document.getElementById('bar').value = pct;
+        document.getElementById('label').textContent = text;
+      });
+      document.getElementById('url').onclick = () => {
+        shell.openExternal('${downloadUrl}');
+      };
+    </script>
+  </body></html>`;
+  win.loadURL('data:text/html;charset=utf-8,' + encodeURIComponent(html));
+  return {
+    set(pct, text) {
+      try { win.webContents.send('progress', pct, text); } catch (e) { /* window closed */ }
+    },
+    close() {
+      try { win.close(); } catch (e) { /* already closed */ }
+    }
+  };
+}
+
+async function promptAndInstall(userDataDir) {
+  getElectronModules();
+  if (!BrowserWindowModule) return null;
+  if (askWindowOpen) return null; // never show two ask windows
+  askWindowOpen = true;
+
+  let result;
+  try {
+    result = await showAskWindow();
+  } finally {
+    askWindowOpen = false;
+  }
+
+  if (!result.download) {
+    // "Để sau": ask again on next launch; ticked "không hỏi lại" -> never.
+    writeConfig(userDataDir, { wineSetup: result.neverAgain ? 'declined-permanent' : 'declined' });
+    return null;
+  }
+
+  const progress = showProgressWindow();
+  try {
+    let lastUpdate = 0;
+    const wine = await installDownloadedWine(userDataDir, (got, total) => {
+      const now = Date.now();
+      if (now - lastUpdate < 500) return; // throttle IPC updates
+      lastUpdate = now;
+      const pct = Math.round((got / total) * 100);
+      progress.set(pct, `Đang tải… ${Math.round(got / 1024 / 1024)}MB / ${Math.round(total / 1024 / 1024)}MB (${pct}%)`);
+    });
+    progress.set(100, 'Đang giải nén và chuẩn bị…');
+
+    // First prefix init (~10-30s, done once)
+    const prefix = process.env.ZCALL_WINEPREFIX || path.join(userDataDir, 'zcall-wine');
+    spawnSync(wine, ['wineboot', '-u'], {
+      env: Object.assign({}, process.env, { WINEPREFIX: prefix, WINEDEBUG: '-all' }),
+      stdio: 'ignore',
+      timeout: 180000
+    });
+
+    progress.close();
+
+    process.env.ZCALL_WINE = wine;
+    process.env.ZCALL_WINEPREFIX = prefix;
+    if (!process.env.WINEDEBUG) process.env.WINEDEBUG = '-all';
+    writeConfig(userDataDir, { wineSetup: 'ready' });
+
+    if (NotificationModule && NotificationModule.isSupported()) {
+      new NotificationModule({
+        title: 'Zalo',
+        body: 'Tính năng gọi điện đã sẵn sàng! Hãy thử gọi một cuộc.'
+      }).show();
+    }
+    return wine;
+  } catch (e) {
+    progress.close();
+    const parent = BrowserWindowModule.getFocusedWindow() || BrowserWindowModule.getAllWindows()[0];
+    if (dialogModule) {
+      await dialogModule.showMessageBox(parent, {
+        type: 'error',
+        title: 'Zalo — Tính năng gọi điện',
+        message: 'Không thể tải Wine',
+        detail: String((e && e.message) || e) + '\n\nBạn có thể thử lại từ menu khay hệ thống, hoặc cài Wine bằng lệnh: sudo apt install wine'
+      });
+    }
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+function launch({ userDataDir }) {
+  if (process.env.ZCALL_DISABLE) return false;
+
+  const prefix = process.env.ZCALL_WINEPREFIX || path.join(userDataDir, 'zcall-wine');
+  const wine = process.env.ZCALL_WINE || findWine() || findDownloadedWine(userDataDir);
+
+  if (!wine) {
+    // First run with no wine anywhere: ask the user (async — never block the
+    // ready handler). Silent only when the user ticked "không hỏi lại" on a
+    // previous decline, unless ZCALL_AUTO_SETUP=1 forces a silent download.
+    const cfg = readConfig(userDataDir);
+    if (cfg.wineSetup === 'declined-permanent' && process.env.ZCALL_AUTO_SETUP !== '1') {
+      console.error('[zcall-bridge] wine setup declined permanently — calls unavailable');
+      return false;
+    }
+    console.log('[zcall-bridge] no wine found, prompting user to set up...');
+    promptAndInstall(userDataDir).then((w) => {
+      if (w) console.log('[zcall-bridge] portable wine ready:', w);
+    }).catch((e) => console.error('[zcall-bridge] setup failed:', e.message));
+    return false;
+  }
+
+  // Ensure the prefix exists
+  if (!fs.existsSync(path.join(prefix, 'drive_c'))) {
+    console.log('[zcall-bridge] initializing wine prefix:', prefix);
+    try {
+      spawnSync(wine, ['wineboot', '-u'], {
+        env: Object.assign({}, process.env, { WINEPREFIX: prefix, WINEDEBUG: '-all' }),
+        stdio: 'ignore',
+        timeout: 180000
+      });
+    } catch (e) {
+      console.error('[zcall-bridge] wineboot failed:', e.message);
+    }
+  }
+
+  // Export for the patched main-dist spawn code
+  process.env.ZCALL_WINE = wine;
+  process.env.ZCALL_WINEPREFIX = prefix;
+  if (!process.env.WINEDEBUG) process.env.WINEDEBUG = '-all';
+
+  console.log('[zcall-bridge] wine ready:', wine, '(prefix:', prefix + ')');
+  return true;
+}
+
+function openSetupDialog({ userDataDir }) {
+  getElectronModules();
+  const wine = process.env.ZCALL_WINE || findWine() || findDownloadedWine(userDataDir);
+  if (wine) {
+    if (dialogModule) {
+      dialogModule.showMessageBox({
+        type: 'info',
+        title: 'Zalo — Tính năng gọi điện',
+        message: 'Tính năng gọi điện đang hoạt động',
+        detail: 'Wine đang dùng: ' + wine
+      });
+    }
+    return;
+  }
+  promptAndInstall(userDataDir);
+}
+
+function shutdown() {
+  // Kill the whole wine session for our prefix: ZaloCall.exe dies with the
+  // app (the call-v2 module kills it), but pipebridge.exe is spawned
+  // fire-and-forget and would keep wineserver alive forever. wineserver -k
+  // terminates wineserver and every wine client in this prefix.
+  const wine = process.env.ZCALL_WINE;
+  const prefix = process.env.ZCALL_WINEPREFIX;
+  if (!wine || !prefix) return;
+
+  const wineserverPath = path.join(path.dirname(wine), 'wineserver');
+  if (!fs.existsSync(wineserverPath)) return;
+
+  try {
+    spawnSync(wineserverPath, ['-k'], {
+      env: Object.assign({}, process.env, { WINEPREFIX: prefix, WINEDEBUG: '-all' }),
+      stdio: 'ignore',
+      timeout: 10000
+    });
+  } catch (e) {
+    console.error('[zcall-bridge] wineserver -k failed:', e.message);
+  }
+
+  // Hard-kill any lingering wine processes that still serve OUR prefix (the
+  // -k above normally suffices, but during quit races a fresh server can
+  // appear or winedevice can outlive its killed server).
+  try {
+    for (const name of ['wineserver', 'winedevice.exe']) {
+      let out = '';
+      try { out = execSync('pgrep -x ' + name, { encoding: 'utf8' }); } catch (_) { continue; }
+      for (const pid of out.trim().split('\n')) {
+        if (!pid) continue;
+        let env = '';
+        try { env = fs.readFileSync('/proc/' + pid + '/environ', 'utf8'); } catch (_) { continue; }
+        if (env.includes(prefix)) {
+          process.kill(Number(pid), 'SIGKILL');
+        }
+      }
+    }
+  } catch (_) { /* nothing left */ }
+}
+
+module.exports = {
+  launch,
+  openSetupDialog,
+  shutdown,
+  // internal (testability)
+  _installDownloadedWine: installDownloadedWine,
+};

--- a/plugins/zcall-bridge/index.js
+++ b/plugins/zcall-bridge/index.js
@@ -599,8 +599,48 @@ function launch({ userDataDir }) {
   process.env.ZCALL_WINEPREFIX = prefix;
   if (!process.env.WINEDEBUG) process.env.WINEDEBUG = '-all';
 
+  // Streamproxy: the capture shim is preloaded into the helper at ALL times.
+  // It is inert while the bridge display is down (captures fall through to
+  // the real display) and it signals a share request via a file, which the
+  // watcher below turns into an automatic bridge start — no tray click
+  // needed when the user hits "Share screen".
+  const proxySo = path.join(__dirname, '..', '..', 'zcall-bridge', 'streamproxy.so');
+  if (fs.existsSync(proxySo)) {
+    process.env.ZCALL_PROXY_SO = proxySo;
+    process.env.ZCALL_PROXY_LOG = path.join(os.homedir(), '.config', 'ZaloData', 'zcall-proxy.log');
+    process.env.ZCALL_PROXY_REQUEST = path.join(os.homedir(), '.config', 'ZaloData', 'zcall-share.request');
+    // Warm the resolution cache now so the first share-screen request does
+    // not pay the synchronous xrandr call while the user waits.
+    try {
+      const out = execSync('xrandr --query 2>/dev/null | grep -m1 "\\*" | awk \'{print $1}\'', { encoding: 'utf8' });
+      if (/^\d+x\d+$/.test(out.trim())) cachedBridgeRes = out.trim();
+    } catch (e) { /* default */ }
+    watchShareRequests();
+  }
+
   console.log('[zcall-bridge] wine ready:', wine, '(prefix:', prefix + ')');
   return true;
+}
+
+/**
+ * Watches the share-request file touched by the streamproxy shim when
+ * ZaloCall starts capturing while the bridge display is down. Starting the
+ * bridge pops the compositor's permission dialog automatically.
+ */
+let lastAutoBridgeAt = 0;
+function watchShareRequests() {
+  setInterval(() => {
+    const f = process.env.ZCALL_PROXY_REQUEST;
+    if (!f || !fs.existsSync(f)) return;
+    try { fs.unlinkSync(f); } catch (e) { /* gone */ }
+    if (!isWaylandSession() || screenBridgeActive()) return;
+    // Cooldown: if the user denied the portal, don't nag again right away
+    // (the tray menu remains available for a manual retry).
+    if (Date.now() - lastAutoBridgeAt < 90000) return;
+    lastAutoBridgeAt = Date.now();
+    debugLog('screenbridge: share request detected — starting bridge');
+    startScreenBridge();
+  }, 200);
 }
 
 /**
@@ -937,6 +977,142 @@ function shutdown() {
   const prefix = process.env.ZCALL_WINEPREFIX;
   if (!prefix) return;
   killWineSession(prefix);
+  stopScreenBridge();
+}
+
+// ---------------------------------------------------------------------------
+// Wayland screen-share bridge
+//
+// On Wayland, wine's X11 screen capture cannot see the desktop (XWayland is
+// isolated). This bridge renders the Wayland screen into a headless Xvfb
+// display via the XDG ScreenCast portal. ZaloCall keeps running natively on
+// the real display; the streamproxy.so shim (LD_PRELOAD, preloaded via
+// ZCALL_PROXY_SO in the patched spawn env) redirects its screen-capture
+// reads (XGetImage/XShmGetImage/xcb_get_image on the root) to the bridge
+// display, so "share screen" captures the bridged content while the call UI
+// stays a normal window. The shim also touches a request file when a
+// capture starts while the bridge is down — watchShareRequests() turns that
+// into an automatic bridge start, so the compositor's permission dialog
+// pops by itself when the user hits "Share screen".
+// ---------------------------------------------------------------------------
+
+const BRIDGE_DISPLAY = ':99';
+let bridgeProcs = [];
+let bridgeGranted = false;
+let cachedBridgeRes = null;
+
+function isWaylandSession() {
+  return process.env.XDG_SESSION_TYPE === 'wayland';
+}
+
+function screenBridgeActive() {
+  return bridgeProcs.some((p) => p && p.exitCode === null && !p.killed);
+}
+
+function startScreenBridge() {
+  getElectronModules();
+  if (screenBridgeActive()) {
+    if (dialogModule) {
+      dialogModule.showMessageBox({
+        type: 'info',
+        title: 'Zalo — Chia sẻ màn hình',
+        message: 'Bridge đang hoạt động',
+        detail: 'Màn hình ảo ' + BRIDGE_DISPLAY + ' đã sẵn sàng. Cuộc gọi hoạt động hoàn toàn như bình thường — khi bấm Share screen, hình chia sẻ sẽ được lấy từ màn hình thật qua bridge.'
+      });
+    }
+    return true;
+  }
+
+  const pyPath = path.join(__dirname, '..', '..', 'zcall-bridge', 'screenbridge.py');
+  if (!fs.existsSync(pyPath)) {
+    if (dialogModule) {
+      dialogModule.showMessageBox({
+        type: 'error', title: 'Zalo — Chia sẻ màn hình',
+        message: 'Thiếu thành phần bridge',
+        detail: 'Không tìm thấy screenbridge.py tại:\n' + pyPath
+      });
+    }
+    return false;
+  }
+
+  // streamproxy.so (LD_PRELOAD shim) redirects ZaloCall's screen-capture
+  // reads from the real display root to the bridge display, so the call UI
+  // stays 100% native while "share screen" captures the bridged stream.
+  // It is compiled by scripts/setup-zcall-bridge.js.
+  const proxySoPath = path.join(__dirname, '..', '..', 'zcall-bridge', 'streamproxy.so');
+  if (!fs.existsSync(proxySoPath)) {
+    if (dialogModule) {
+      dialogModule.showMessageBox({
+        type: 'error', title: 'Zalo — Chia sẻ màn hình',
+        message: 'Thiếu thành phần streamproxy',
+        detail: 'Không tìm thấy streamproxy.so tại:\n' + proxySoPath +
+          '\n\nChạy "node scripts/setup-zcall-bridge.js" để build lại.'
+      });
+    }
+    return false;
+  }
+
+  // Resolve the real screen resolution for the Xvfb screen. Cached from app
+  // launch — the synchronous xrandr call would add ~200ms of latency right
+  // when the user is waiting for the permission dialog.
+  let res = cachedBridgeRes;
+  if (!res) {
+    res = '1920x1080';
+    try {
+      const out = execSync('xrandr --query 2>/dev/null | grep -m1 "\\*" | awk \'{print $1}\'', { encoding: 'utf8' });
+      if (/^\d+x\d+$/.test(out.trim())) res = out.trim();
+    } catch (e) { /* default */ }
+    cachedBridgeRes = res;
+  }
+  const [w, h] = res.split('x');
+
+  stopScreenBridge();
+  bridgeGranted = false;
+  try {
+    // Headless Xvfb holds the bridged stream; ZaloCall keeps running on the
+    // real display (native UI) and the streamproxy shim redirects its
+    // screen-capture reads to this display.
+    bridgeProcs.push(spawn('Xvfb', [BRIDGE_DISPLAY, '-screen', '0', w + 'x' + h + 'x24'], { stdio: 'ignore' }));
+    const py = spawn('python3', [pyPath, BRIDGE_DISPLAY], { stdio: ['ignore', 'ignore', 'pipe'] });
+    py.stderr.on('data', (d) => {
+      const s = String(d).trim().slice(0, 300);
+      debugLog('screenbridge: ' + s);
+      // The user granted the portal and gst is rendering into :99 — from
+      // now on the shim's proxied grabs return the stream. (The helper is
+      // never restarted: the shim is preloaded from app launch, and its
+      // fall-through handles the bridge-down state.)
+      if (s.indexOf('got pipewire node') !== -1) {
+        bridgeGranted = true;
+        debugLog('screenbridge: granted — stream ready on ' + BRIDGE_DISPLAY);
+      }
+    });
+    py.on('exit', (code) => {
+      debugLog('screenbridge: python exited code=' + code + ' granted=' + bridgeGranted);
+      stopScreenBridge();
+    });
+    bridgeProcs.push(py);
+    // Let gst create its window, then stretch every window on the Xvfb
+    // display over the whole screen (the gst window title is
+    // "gst-launch-1.0", so match anything).
+    setTimeout(() => {
+      try {
+        execSync(`xdotool search --display ${BRIDGE_DISPLAY} "" 2>/dev/null | while read wid; do xdotool windowsize $wid ${w} ${h} windowmove $wid 0 0; done`, { stdio: 'ignore' });
+      } catch (e) { debugLog('screenbridge xdotool: ' + e.message); }
+    }, 5000);
+  } catch (e) {
+    debugLog('screenbridge start failed: ' + e.message);
+    return false;
+  }
+
+  debugLog('screenbridge started on ' + BRIDGE_DISPLAY + ' res=' + res);
+  return true;
+}
+
+function stopScreenBridge() {
+  for (const p of bridgeProcs) {
+    try { if (p && !p.killed) p.kill(); } catch (e) { /* gone */ }
+  }
+  bridgeProcs = [];
 }
 
 module.exports = {

--- a/plugins/zcall-bridge/index.js
+++ b/plugins/zcall-bridge/index.js
@@ -134,8 +134,14 @@ function validateWine(winePath, prefix) {
       encoding: 'utf8',
       timeout: 30000
     });
-    return res.status === 0 && /pipebridge/.test(res.stdout || '');
+    if (res.status === 0 && /pipebridge/.test(res.stdout || '')) return true;
+    console.error('[zcall-bridge] wine validation failed:',
+      'status=' + res.status,
+      'error=' + (res.error ? res.error.message : ''),
+      'stderr=' + String(res.stderr || '').split('\n').slice(0, 3).join(' | '));
+    return false;
   } catch (e) {
+    console.error('[zcall-bridge] wine validation threw:', e.message);
     return false;
   }
 }
@@ -377,6 +383,17 @@ async function promptAndInstall(userDataDir, failedWine) {
       timeout: 180000
     });
 
+    // Verify the freshly downloaded wine actually works on this machine —
+    // classic wine builds need 32-bit libraries that some systems do not
+    // have.
+    if (!validateWine(wine, prefix)) {
+      const hint = getI386InstallHint();
+      throw new Error(
+        'Wine không chạy được trên máy này — cần thư viện 32-bit.\n\n' +
+        hint.title + '\n' + hint.command
+      );
+    }
+
     progress.close();
 
     process.env.ZCALL_WINE = wine;
@@ -414,19 +431,27 @@ function launch({ userDataDir }) {
   if (process.env.ZCALL_DISABLE) return false;
 
   const prefix = process.env.ZCALL_WINEPREFIX || path.join(userDataDir, 'zcall-wine');
-  const downloadedWine = findDownloadedWine(userDataDir);
-  let wine = process.env.ZCALL_WINE || findWine() || downloadedWine;
 
   // Clean stale wine processes from unclean previous exits
   sweepStaleProcesses(prefix);
 
+  // Candidate wines, best first: explicit env -> our portable runtime
+  // (version we control and test) -> system wine -> Bottles runners.
+  const downloadedWine = findDownloadedWine(userDataDir);
+  const systemWine = findWine();
+  const candidates = [];
+  if (process.env.ZCALL_WINE) candidates.push(process.env.ZCALL_WINE);
+  if (downloadedWine) candidates.push(downloadedWine);
+  if (systemWine && candidates.indexOf(systemWine) === -1) candidates.push(systemWine);
+
+  let wine = null;
   let failedWine = null;
-  if (wine) {
+  for (const candidate of candidates) {
     // Ensure the prefix exists before validating (validation needs a booted prefix)
     if (!fs.existsSync(path.join(prefix, 'drive_c'))) {
       console.log('[zcall-bridge] initializing wine prefix:', prefix);
       try {
-        spawnSync(wine, ['wineboot', '-u'], {
+        spawnSync(candidate, ['wineboot', '-u'], {
           env: Object.assign({}, process.env, { WINEPREFIX: prefix, WINEDEBUG: '-all' }),
           stdio: 'ignore',
           timeout: 180000
@@ -436,20 +461,33 @@ function launch({ userDataDir }) {
       }
     }
 
-    // A found wine is only usable if it can run 32-bit executables. The
-    // downloaded runtime is known-good, so skip the check for it.
-    if (wine !== downloadedWine && !validateWine(wine, prefix)) {
-      console.error('[zcall-bridge] wine cannot run 32-bit apps, treating as unavailable:', wine);
-      failedWine = wine;
-      wine = null;
+    // A wine is only usable if it can run 32-bit executables.
+    if (validateWine(candidate, prefix)) {
+      wine = candidate;
+      break;
     }
+    console.error('[zcall-bridge] wine cannot run 32-bit apps, skipping:', candidate);
+    failedWine = candidate;
   }
 
   if (!wine) {
+    const cfg = readConfig(userDataDir);
+
+    // Downloaded runtime exists but cannot run (machine lacks 32-bit
+    // libraries): re-downloading would loop forever — guide the user
+    // instead, once, without nagging every launch.
+    if (failedWine === downloadedWine) {
+      console.error('[zcall-bridge] downloaded wine broken (missing 32-bit libs?)');
+      if (cfg.wineSetup !== 'broken' && process.env.ZCALL_AUTO_SETUP !== '1') {
+        writeConfig(userDataDir, { wineSetup: 'broken' });
+        showBrokenWineDialog(downloadedWine);
+      }
+      return false;
+    }
+
     // No usable wine: ask the user (async — never block the ready handler).
     // Silent only when the user ticked "không hỏi lại" on a previous
     // decline, unless ZCALL_AUTO_SETUP=1 forces a silent download.
-    const cfg = readConfig(userDataDir);
     if (cfg.wineSetup === 'declined-permanent' && process.env.ZCALL_AUTO_SETUP !== '1') {
       console.error('[zcall-bridge] wine setup declined permanently — calls unavailable');
       return false;
@@ -470,9 +508,65 @@ function launch({ userDataDir }) {
   return true;
 }
 
+/**
+ * Distro-specific command to install the 32-bit libraries the portable wine
+ * needs. Detects the distro from /etc/os-release.
+ */
+function getI386InstallHint() {
+  let idLike = '';
+  try {
+    const osRelease = fs.readFileSync('/etc/os-release', 'utf8');
+    const m = osRelease.match(/^ID(?:_LIKE)?=(.+)$/gm);
+    idLike = (m || []).join('\n').toLowerCase();
+  } catch (e) { /* unknown distro */ }
+
+  if (idLike.includes('fedora') || idLike.includes('rhel') || idLike.includes('centos')) {
+    return {
+      title: 'Cài thư viện 32-bit (Fedora/RHEL):',
+      command: 'sudo dnf install -y glibc.i686 libX11.i686 libXext.i686 freetype.i686 mesa-libGL.i686 pulseaudio-libs.i686 zlib-ng-compat.i686 gstreamer1.i686 gstreamer1-plugins-base.i686 gstreamer1-plugins-good.i686 gstreamer1-plugins-bad-free.i686\n\n(GStreamer 32-bit cần cho video call; gstreamer1-plugin-libav cần RPM Fusion)\n\nHoặc cài wine hệ thống (tự kéo đủ thư viện):\nsudo dnf install wine'
+    };
+  }
+  if (idLike.includes('arch')) {
+    return {
+      title: 'Cài thư viện 32-bit (Arch):',
+      command: 'sudo pacman -S --needed lib32-glibc lib32-libx11 lib32-libxext lib32-freetype2 lib32-mesa lib32-libpulse lib32-zlib lib32-gstreamer lib32-gst-plugins-base lib32-gst-plugins-good lib32-gst-libav\n\n(GStreamer 32-bit cần cho video call)\n\nHoặc cài wine hệ thống:\nsudo pacman -S wine'
+    };
+  }
+  // default: Debian/Ubuntu family
+  return {
+    title: 'Cài thư viện 32-bit (Ubuntu/Debian):',
+    command: 'sudo dpkg --add-architecture i386 && sudo apt update\nsudo apt install -y libc6:i386 libx11-6:i386 libfreetype6:i386 libgl1:i386 libpulse0:i386 zlib1g:i386 libgstreamer1.0-0:i386 libgstreamer-plugins-base1.0-0:i386 gstreamer1.0-plugins-good:i386 gstreamer1.0-libav:i386\n\n(GStreamer 32-bit cần cho video call)\n\nHoặc cài wine hệ thống (tự kéo đủ thư viện):\nsudo apt install wine'
+  };
+}
+
+function showBrokenWineDialog(winePath) {
+  getElectronModules();
+  if (!dialogModule) return;
+  const hint = getI386InstallHint();
+  const parent = BrowserWindowModule.getFocusedWindow() || BrowserWindowModule.getAllWindows()[0];
+  dialogModule.showMessageBox(parent, {
+    type: 'warning',
+    title: 'Zalo — Tính năng gọi điện',
+    message: 'Wine không chạy được trên máy này',
+    detail: 'Wine cần các thư viện 32-bit mà máy bạn chưa có.\n\n' +
+      hint.title + '\n' + hint.command +
+      '\n\nSau khi cài xong, khởi động lại Zalo là gọi được.\n\n' +
+      'Wine đã tải: ' + winePath
+  });
+}
+
 function openSetupDialog({ userDataDir }) {
   getElectronModules();
-  const wine = process.env.ZCALL_WINE || findWine() || findDownloadedWine(userDataDir);
+  const prefix = process.env.ZCALL_WINEPREFIX || path.join(userDataDir, 'zcall-wine');
+  const downloadedWine = findDownloadedWine(userDataDir);
+  const wine = process.env.ZCALL_WINE || findWine() || downloadedWine;
+
+  // Downloaded runtime broken? Guide instead of re-downloading forever.
+  if (wine === downloadedWine && !validateWine(wine, prefix)) {
+    showBrokenWineDialog(downloadedWine);
+    return;
+  }
+
   if (wine) {
     if (dialogModule) {
       dialogModule.showMessageBox({

--- a/plugins/zcall-bridge/index.js
+++ b/plugins/zcall-bridge/index.js
@@ -107,6 +107,48 @@ function findDownloadedWine(userDataDir) {
   return fs.existsSync(p) ? p : null;
 }
 
+/**
+ * Verify that this wine can actually run 32-bit executables (ZaloCall is a
+ * PE32 binary). Runs pipebridge.exe --version (a 32-bit exe) with a timeout.
+ * Returns true only when it prints the expected output.
+ */
+function validateWine(winePath, prefix) {
+  const pipebridgePath = path.join(__dirname, '..', '..', 'app', 'native', 'qt-call-and-cap', 'pipebridge.exe');
+  if (!fs.existsSync(pipebridgePath)) return false;
+  try {
+    const res = spawnSync(winePath, [pipebridgePath, '--version'], {
+      env: Object.assign({}, process.env, { WINEPREFIX: prefix, WINEDEBUG: '-all' }),
+      encoding: 'utf8',
+      timeout: 30000
+    });
+    return res.status === 0 && /pipebridge/.test(res.stdout || '');
+  } catch (e) {
+    return false;
+  }
+}
+
+/**
+ * Kill leftover wine processes of OUR prefix (e.g. winedevice orphans left
+ * by an unclean kill -9 of a previous session). Safe to run at launch: no
+ * legit session exists yet.
+ */
+function sweepStaleProcesses(prefix) {
+  try {
+    for (const name of ['wineserver', 'winedevice.exe']) {
+      let out = '';
+      try { out = execSync('pgrep -x ' + name, { encoding: 'utf8' }); } catch (_) { continue; }
+      for (const pid of out.trim().split('\n')) {
+        if (!pid) continue;
+        let env = '';
+        try { env = fs.readFileSync('/proc/' + pid + '/environ', 'utf8'); } catch (_) { continue; }
+        if (env.includes(prefix)) {
+          process.kill(Number(pid), 'SIGKILL');
+        }
+      }
+    }
+  } catch (_) { /* nothing stale */ }
+}
+
 // ---------------------------------------------------------------------------
 // Portable wine download + extract
 // ---------------------------------------------------------------------------
@@ -168,7 +210,7 @@ let askWindowOpen = false;
  * Custom always-on-top ask window (native dialogs can get covered by the
  * Zalo main window on Linux DEs). Resolves with the user's choice.
  */
-function showAskWindow() {
+function showAskWindow(failedWine) {
   const { ipcMain } = require('electron');
   const win = new BrowserWindowModule({
     width: 540,
@@ -183,6 +225,9 @@ function showAskWindow() {
     webPreferences: { contextIsolation: false, nodeIntegration: true }
   });
   const downloadUrl = process.env.ZCALL_WINE_DOWNLOAD_URL || WINE_DOWNLOAD_URL;
+  const headLine = failedWine
+    ? 'Wine trên máy bạn không tương thích với tính năng gọi (không chạy được ứng dụng 32-bit). Tải bản Wine tương thích?'
+    : 'Tính năng gọi điện cần Wine. Tải và bật ngay bây giờ?';
   const html = `<!DOCTYPE html><html><head><meta charset="utf-8"><style>
     body{font-family:sans-serif;background:#1f1f1f;color:#eee;margin:0;padding:20px 24px;-webkit-app-region:drag}
     h3{margin:0 0 8px;font-size:16px}
@@ -195,7 +240,7 @@ function showAskWindow() {
     #no{background:#3a3a3a;color:#eee}
   </style></head><body>
     <h3>Zalo — Tính năng gọi điện</h3>
-    <p>Tính năng gọi điện cần Wine. Tải và bật ngay bây giờ?<br>
+    <p>${headLine}<br>
        Sẽ tải ~54MB về lưu trong dữ liệu của Zalo — không cần quyền quản trị,
        không ảnh hưởng hệ thống.</p>
     <div id="url" title="Mở nguồn tải trong trình duyệt">Nguồn tải: ${downloadUrl}</div>
@@ -280,7 +325,7 @@ function showProgressWindow() {
   };
 }
 
-async function promptAndInstall(userDataDir) {
+async function promptAndInstall(userDataDir, failedWine) {
   getElectronModules();
   if (!BrowserWindowModule) return null;
   if (askWindowOpen) return null; // never show two ask windows
@@ -288,7 +333,7 @@ async function promptAndInstall(userDataDir) {
 
   let result;
   try {
-    result = await showAskWindow();
+    result = await showAskWindow(failedWine);
   } finally {
     askWindowOpen = false;
   }
@@ -356,36 +401,51 @@ function launch({ userDataDir }) {
   if (process.env.ZCALL_DISABLE) return false;
 
   const prefix = process.env.ZCALL_WINEPREFIX || path.join(userDataDir, 'zcall-wine');
-  const wine = process.env.ZCALL_WINE || findWine() || findDownloadedWine(userDataDir);
+  const downloadedWine = findDownloadedWine(userDataDir);
+  let wine = process.env.ZCALL_WINE || findWine() || downloadedWine;
+
+  // Clean stale wine processes from unclean previous exits
+  sweepStaleProcesses(prefix);
+
+  let failedWine = null;
+  if (wine) {
+    // Ensure the prefix exists before validating (validation needs a booted prefix)
+    if (!fs.existsSync(path.join(prefix, 'drive_c'))) {
+      console.log('[zcall-bridge] initializing wine prefix:', prefix);
+      try {
+        spawnSync(wine, ['wineboot', '-u'], {
+          env: Object.assign({}, process.env, { WINEPREFIX: prefix, WINEDEBUG: '-all' }),
+          stdio: 'ignore',
+          timeout: 180000
+        });
+      } catch (e) {
+        console.error('[zcall-bridge] wineboot failed:', e.message);
+      }
+    }
+
+    // A found wine is only usable if it can run 32-bit executables. The
+    // downloaded runtime is known-good, so skip the check for it.
+    if (wine !== downloadedWine && !validateWine(wine, prefix)) {
+      console.error('[zcall-bridge] wine cannot run 32-bit apps, treating as unavailable:', wine);
+      failedWine = wine;
+      wine = null;
+    }
+  }
 
   if (!wine) {
-    // First run with no wine anywhere: ask the user (async — never block the
-    // ready handler). Silent only when the user ticked "không hỏi lại" on a
-    // previous decline, unless ZCALL_AUTO_SETUP=1 forces a silent download.
+    // No usable wine: ask the user (async — never block the ready handler).
+    // Silent only when the user ticked "không hỏi lại" on a previous
+    // decline, unless ZCALL_AUTO_SETUP=1 forces a silent download.
     const cfg = readConfig(userDataDir);
     if (cfg.wineSetup === 'declined-permanent' && process.env.ZCALL_AUTO_SETUP !== '1') {
       console.error('[zcall-bridge] wine setup declined permanently — calls unavailable');
       return false;
     }
-    console.log('[zcall-bridge] no wine found, prompting user to set up...');
-    promptAndInstall(userDataDir).then((w) => {
+    console.log('[zcall-bridge] no usable wine, prompting user to set up...');
+    promptAndInstall(userDataDir, failedWine).then((w) => {
       if (w) console.log('[zcall-bridge] portable wine ready:', w);
     }).catch((e) => console.error('[zcall-bridge] setup failed:', e.message));
     return false;
-  }
-
-  // Ensure the prefix exists
-  if (!fs.existsSync(path.join(prefix, 'drive_c'))) {
-    console.log('[zcall-bridge] initializing wine prefix:', prefix);
-    try {
-      spawnSync(wine, ['wineboot', '-u'], {
-        env: Object.assign({}, process.env, { WINEPREFIX: prefix, WINEDEBUG: '-all' }),
-        stdio: 'ignore',
-        timeout: 180000
-      });
-    } catch (e) {
-      console.error('[zcall-bridge] wineboot failed:', e.message);
-    }
   }
 
   // Export for the patched main-dist spawn code

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -26,9 +26,22 @@ async function main() {
       logger.warn('package.json.bak not found, version will be unknown');
     }
 
+    // A leftover bundled runtime (e.g. from a crashed previous run) would
+    // silently bloat the standard variants — start clean; Phase 3 re-bundles.
+    fs.rmSync(path.join(APP_DIR, 'native', 'wine-runtime'), { recursive: true, force: true });
+
     // Phase 1: Build original Zalo
     logger.step('PHASE 1: Building Zalo (Original)');
     await build('(Original)', '');
+
+    // Phase 1.5: Full variant of the original (no ZaDark) — wine bundled.
+    logger.step('PHASE 1.5: Building Zalo (Full — wine bundled, no ZaDark)');
+    await bundleWineRuntime();
+    await build('(Full — wine bundled)', '-PlainFull');
+    // Remove the runtime again — the standard variants must not contain it,
+    // and a leftover from a previous run would silently bloat them (and the
+    // next Full build) to the Full size.
+    fs.rmSync(path.join(APP_DIR, 'native', 'wine-runtime'), { recursive: true, force: true });
 
     // Phase 2: Apply ZaDark integration and build final product
     logger.step('PHASE 2: Building Zalo (with ZaDark)');
@@ -36,6 +49,13 @@ async function main() {
     // Patch ZaDark directly into APP_DIR
     await integrateZaDark();
     await build('(with ZaDark)', '-ZaDark');
+
+    // Phase 3: Full variant of the ZaDark build — wine bundled, so the call
+    // feature works out of the box with no first-run download.
+    logger.step('PHASE 3: Building Zalo (Full — wine bundled, with ZaDark)');
+    await bundleWineRuntime();
+    await build('(Full — wine bundled)', '-Full');
+    fs.rmSync(path.join(APP_DIR, 'native', 'wine-runtime'), { recursive: true, force: true });
 
     // Final summary
     logger.step('BUILD SUMMARY');
@@ -50,6 +70,35 @@ async function main() {
     logger.error('Main workflow failed:', error.message);
     process.exit(1);
   }
+}
+
+// Keep in sync with WINE_DOWNLOAD_URL in plugins/zcall-bridge/index.js
+const WINE_DOWNLOAD_URL =
+  'https://github.com/Kron4ek/Wine-Builds/releases/download/11.14/wine-11.14-amd64.tar.xz';
+
+async function bundleWineRuntime() {
+  const target = path.join(APP_DIR, 'native', 'wine-runtime');
+  if (fs.existsSync(path.join(target, 'bin', 'wine'))) {
+    logger.dim('wine runtime already bundled, skipping download');
+    return;
+  }
+  const tarball = path.join(APP_DIR, 'native', 'wine-bundle.tar.xz');
+  logger.info('Downloading portable wine for the Full variant...');
+  try {
+    execSync(`curl -L --fail -o "${tarball}" "${WINE_DOWNLOAD_URL}"`, {
+      cwd: BASE_DIR, stdio: 'inherit'
+    });
+    fs.mkdirSync(target, { recursive: true });
+    execSync(`tar -xf "${tarball}" -C "${target}" --strip-components=1`, {
+      cwd: BASE_DIR, stdio: 'pipe'
+    });
+  } finally {
+    try { fs.unlinkSync(tarball); } catch (e) { /* none */ }
+  }
+  if (!fs.existsSync(path.join(target, 'bin', 'wine'))) {
+    throw new Error('wine binary not found after extract');
+  }
+  logger.success('wine runtime bundled into app/native/wine-runtime');
 }
 
 async function integrateZaDark() {
@@ -85,8 +134,9 @@ async function build(buildName = '', outputSuffix = '') {
     let buildCommand;
     let zadarkVersion = null;
 
-    if (outputSuffix === '-ZaDark') {
-      // Read ZaDark version for custom naming
+    if (outputSuffix === '-ZaDark' || outputSuffix === '-Full') {
+      // Read ZaDark version for custom naming (the Full variant also builds
+      // on the ZaDark-integrated app directory)
       const zadarkPackagePath = path.join(BASE_DIR, 'plugins', 'zadark', 'package.json');
       zadarkVersion = 'unknown';
 
@@ -99,9 +149,13 @@ async function build(buildName = '', outputSuffix = '') {
         }
       }
 
-      artifactName = `Zalo-${ZALO_VERSION}+ZaDark-${zadarkVersion}-${commitHash}.AppImage`;
+      artifactName = `Zalo-${ZALO_VERSION}+ZaDark-${zadarkVersion}-${commitHash}${outputSuffix}.AppImage`;
       buildCommand = `npx electron-builder --linux --config.linux.artifactName="${artifactName}" -c.extraMetadata.version=${ZALO_VERSION} --publish=never`;
       logger.info(`Building ${buildName} with Zalo: ${ZALO_VERSION}, ZaDark: ${zadarkVersion}, Commit: ${commitHash}`);
+    } else if (outputSuffix === '-PlainFull') {
+      artifactName = `Zalo-${ZALO_VERSION}-${commitHash}-Full.AppImage`;
+      buildCommand = `npx electron-builder --linux --config.linux.artifactName="${artifactName}" -c.extraMetadata.version=${ZALO_VERSION} --publish=never`;
+      logger.info(`Building ${buildName} with Zalo: ${ZALO_VERSION}, Commit: ${commitHash}`);
     } else {
       artifactName = `Zalo-${ZALO_VERSION}-${commitHash}.AppImage`;
       buildCommand = `npx electron-builder --linux --config.linux.artifactName="${artifactName}" -c.extraMetadata.version=${ZALO_VERSION} --publish=never`;
@@ -110,7 +164,7 @@ async function build(buildName = '', outputSuffix = '') {
     // Write build-info.json to the app directory so the AppImage will contain its metadata
     const buildInfo = {
       version: ZALO_VERSION,
-      zadarkVersion: outputSuffix === '-ZaDark' ? zadarkVersion : null,
+      zadarkVersion: (outputSuffix === '-ZaDark' || outputSuffix === '-Full') ? zadarkVersion : null,
       commit: commitHash,
       buildDate: new Date().toISOString()
     };
@@ -162,7 +216,7 @@ async function build(buildName = '', outputSuffix = '') {
         logger.dim(`SHA256: ${fileSha256}`);
         
         builtFiles.push({
-          type: outputSuffix === '-ZaDark' ? '🎨 ZaDark' : '📦 Original',
+          type: outputSuffix === '-Full' ? '🍷 Full (ZaDark)' : outputSuffix === '-PlainFull' ? '🍷 Full' : outputSuffix === '-ZaDark' ? '🎨 ZaDark' : '📦 Original',
           name: appImageName,
           sizeStr
         });
@@ -175,7 +229,7 @@ async function build(buildName = '', outputSuffix = '') {
 
     // Export build info to GitHub Actions
     if (process.env.GITHUB_OUTPUT) {
-      const prefix = outputSuffix === '-ZaDark' ? 'zadark_' : 'original_';
+      const prefix = outputSuffix === '-PlainFull' ? 'plainfull_' : outputSuffix === '-Full' ? 'full_' : outputSuffix === '-ZaDark' ? 'zadark_' : 'original_';
 
       // Export build-specific info
       const specificOutputs = [

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -22,6 +22,11 @@ async function main() {
 
       logger.step('Step 4: Preparing Zalo app');
       await require('./prepare-app.js').main();
+
+      // Optional: call engine under Wine — failure must not break the build.
+      logger.step('Step 4.5: Setting up zcall-bridge (optional call engine)');
+      try { await require('./setup-zcall-bridge.js').main(); }
+      catch (e) { logger.warn('zcall-bridge setup failed, calls unavailable: ' + e.message); }
     }
     if (process.env.BUILD === 'true') {
       logger.step('Step 5: Building AppImages');

--- a/scripts/patches/patch-zcall-callgate.js
+++ b/scripts/patches/patch-zcall-callgate.js
@@ -1,0 +1,93 @@
+/**
+ * patch-zcall-callgate.js
+ *
+ * Fixes the call-button gate that accidentally disables calls on Linux.
+ *
+ * Zalo's call controller computes a support flag from the OS release version:
+ *
+ *   let ae=()=>{{
+ *     const e=$znode.os.release();
+ *     if(e){ if(Number(e.split(".")[0])<17) return ae=()=>!1,!1 }
+ *   }
+ *   return ae=()=>!0,ae()};
+ *   const ie=ae();   // -> isSupport() uses this
+ *
+ * This was written for macOS (Darwin kernel >= 17), but on Linux
+ * os.release() is the Linux kernel version (e.g. "7.0.0-30-generic"),
+ * so Number("7") < 17 makes the gate false and the call button stays
+ * disabled / makeCall() hits the "[zcall-v2] Call is not supported!" stub.
+ *
+ * Patch: skip the version check on Linux, keep it intact on other platforms.
+ */
+
+const fs = require('fs-extra');
+const path = require('path');
+const logger = require('../utils/logger');
+
+const PC_DIST = path.join(__dirname, '..', '..', 'app', 'pc-dist');
+
+// Hash part of the filenames changes per Zalo version — glob by prefix.
+const GLOB_TARGETS = [
+  path.join(PC_DIST, 'compact-app-pc.*.js'),
+  path.join(PC_DIST, 'search-worker.*.js'),
+  path.join(PC_DIST, 'sync-v2-sub-worker.*.js'),
+  path.join(PC_DIST, 'lazy', 'default-login-main-startup-shared-worker-znotification.*.js'),
+];
+
+const ORIGINAL = 'let ae=()=>{{const e=$znode.os.release();if(e){if(Number(e.split(".")[0])<17)return ae=()=>!1,!1}}return ae=()=>!0,ae()};';
+const PATCHED = 'let ae=()=>{{const e=$znode.os.release();if(e){if("linux"!==$znode.os.platform()&&Number(e.split(".")[0])<17)return ae=()=>!1,!1}}return ae=()=>!0,ae()};';
+
+// Static feature defaults have calls disabled (enableCall:!1, enableVideoCall:!1);
+// the server may override them via settings.chat.enable_call, but if it does
+// not send them, flip the defaults so calls are available out of the box.
+const DEFAULTS_ORIGINAL = 'enableCall:!1,enableTag:!0,enableVideoCall:!1';
+const DEFAULTS_PATCHED = 'enableCall:!0,enableTag:!0,enableVideoCall:!0';
+
+async function main() {
+  let patchedCount = 0;
+
+  for (const pattern of GLOB_TARGETS) {
+    // resolve the first matching file (hashes change per Zalo version)
+    const dir = path.dirname(pattern);
+    const base = path.basename(pattern);
+    const [prefix, suffix] = base.split('*');
+    const file = fs.existsSync(dir)
+      ? (fs.readdirSync(dir).find(f => f.startsWith(prefix) && f.endsWith(suffix || '')) || null)
+      : null;
+
+    if (!file) {
+      logger.warn('callgate target not found: ' + pattern);
+      continue;
+    }
+    const filePath = path.join(dir, file);
+
+    let content = fs.readFileSync(filePath, 'utf8');
+    let changed = false;
+
+    if (!content.includes(PATCHED) && content.includes(ORIGINAL)) {
+      content = content.split(ORIGINAL).join(PATCHED);
+      changed = true;
+    }
+    if (content.includes(DEFAULTS_ORIGINAL)) {
+      content = content.split(DEFAULTS_ORIGINAL).join(DEFAULTS_PATCHED);
+      changed = true;
+    }
+
+    if (!changed) {
+      logger.dim('callgate already patched: ' + file);
+      patchedCount++;
+      continue;
+    }
+    fs.writeFileSync(filePath, content, 'utf8');
+    logger.dim('callgate patched: ' + file);
+    patchedCount++;
+  }
+
+  if (patchedCount > 0) logger.success(`zcall callgate patched (${patchedCount} files)`);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { main };

--- a/scripts/patches/patch-zcall-callv2.js
+++ b/scripts/patches/patch-zcall-callv2.js
@@ -1,0 +1,143 @@
+/**
+ * patch-zcall-callv2.js
+ *
+ * Makes the call-v2 helper (ZaloCall.exe) work on Linux by spawning it under
+ * Wine with a named-pipe -> TCP bridge.
+ *
+ * Background:
+ *   Zalo PC 26.x does not use the old zcall .node addon anymore. The main
+ *   process spawns a Qt helper (plugins/capture/ZaloCall.exe on Windows,
+ *   ZaloHelper.app on macOS) and talks to it over two local channels with
+ *   AES-128-CBC-encrypted JSON:
+ *     - Windows: named pipes  \\.\pipe\PipeZCallRecv / PipeZCallSend
+ *     - macOS:   unix sockets /tmp/socketzalorecv2021 / socketzalosend2021
+ *
+ *   On Linux neither branch works (no macOS helper; Wine 9.9+ removed AF_UNIX
+ *   support, so unix sockets are out). This patch:
+ *     1. makes the main process listen on TCP ports 29631/29632 on Linux
+ *     2. spawns pipebridge.js under Wine (pure-Node, Electron 2 runtime),
+ *        which hosts the named pipes and pumps bytes to the TCP ports
+ *     3. spawns the Windows ZaloCall.exe under Wine with the named-pipe args
+ *
+ *   The transport crypto, message handling and renderer IPC stay untouched.
+ */
+
+const fs = require('fs-extra');
+const path = require('path');
+const logger = require('../utils/logger');
+
+const MAIN_JS = path.join(__dirname, '..', '..', 'app', 'main-dist', 'main.js');
+
+const REPLACEMENTS = [
+  // 1. channel addresses: TCP ports on Linux (inline platform checks — no new
+  //    variables: the module scope already uses every short name)
+  {
+    from: 'y="win32"===n("jle/").platform(),g=y?"\\\\\\\\.\\\\pipe\\\\PipeZCallSend":"/tmp/socketzalosend2021",v=y?"\\\\\\\\.\\\\pipe\\\\PipeZCallRecv":"/tmp/socketzalorecv2021"',
+    to: 'y="win32"===n("jle/").platform(),g=y?"\\\\\\\\.\\\\pipe\\\\PipeZCallSend":"linux"===n("jle/").platform()?29632:"/tmp/socketzalosend2021",v=y?"\\\\\\\\.\\\\pipe\\\\PipeZCallRecv":"linux"===n("jle/").platform()?29631:"/tmp/socketzalorecv2021"',
+  },
+  // 2. binary path: add Linux branch before the macOS branch
+  {
+    from: ':(e=u()?o.join(__dirname,"..","native","qt-call-cap-mac","ZaloHelper.app")',
+    to: ':("linux"===process.platform?e=o.join(__dirname,"..","native","qt-call-and-cap","ZaloCall.exe"):(e=u()?o.join(__dirname,"..","native","qt-call-cap-mac","ZaloHelper.app")',
+  },
+  {
+    from: 'e=o.join(e,"Contents","MacOS","ZaloCall")),e}();',
+    to: 'e=o.join(e,"Contents","MacOS","ZaloCall"))),e}();',
+  },
+  // 3. spawn: on Linux, start pipebridge then ZaloCall under Wine
+  {
+    from: 'A=i(e,[v,g]),A.stdout.setEncoding("utf8")',
+    to: '"linux"===process.platform?(i(process.env.ZCALL_WINE||"wine",[o.join(__dirname,"..","native","qt-call-and-cap","pipebridge.exe"),"29631","29632"]),A=i(process.env.ZCALL_WINE||"wine",[e,"\\\\\\\\.\\\\pipe\\\\PipeZCallRecv","\\\\\\\\.\\\\pipe\\\\PipeZCallSend"])):A=i(e,[v,g]),A.stdout.setEncoding("utf8")',
+  },
+  // 4. listen: TCP on Linux, unix socket elsewhere
+  {
+    from: 'I.listen(v,(',
+    to: 'I.listen("linux"===process.platform?{port:v,host:"127.0.0.1"}:v,(',
+  },
+  {
+    from: 'C.listen(g,(',
+    to: 'C.listen("linux"===process.platform?{port:g,host:"127.0.0.1"}:g,(',
+  },
+  // 5. EADDRINUSE recovery: skip fs.unlink on Linux (v/g are ports there)
+  {
+    from: 'y||a.unlink(v,',
+    to: '"linux"===process.platform||y||a.unlink(v,',
+  },
+  {
+    from: 'y||(U=!1,a.unlink(g,',
+    to: '"linux"===process.platform||y||(U=!1,a.unlink(g,',
+  },
+  // 6. Re-send the init payload right before every makeCall. The helper
+  //    rejects makeCall with error -11 ("init_error") if it has not seen
+  //    the init data yet; sending O first (same TCP stream, order
+  //    preserved) removes that race.
+  {
+    from: '.on("call-send-to-native",((e,t)=>{t._optional?delete t._optional:K(),D(t)}))',
+    to: '.on("call-send-to-native",((e,t)=>{t._optional?delete t._optional:K(),t&&"makeCall"===t.command&&O&&D(O),D(t)}))',
+  },
+  // 7. Fix the send queue's F flag. On the non-win32 path the flag is only
+  //    cleared when the helper sends data back on the send channel — which
+  //    it almost never does — so after the first message every further
+  //    message stalls in the queue forever (init goes through, makeCall
+  //    never arrives). Reset the flag shortly after each write.
+  {
+    from: 'F=!0,e.write(t)',
+    to: 'F=!0,e.write(t),setTimeout((()=>{F=!1,W(e)}),100)',
+  },
+  // 8. Auth token handshake: the main process generates a random token,
+  //    passes it to pipebridge, and requires it as the first line of every
+  //    TCP connection. Drops connections that do not present the token.
+  {
+    from: 'let S,D,O,N,A,C=null,I=null,L=!1,P=[],M=!1,k=!0,x=[],F=!1,U=!1',
+    to: 'let S,D,O,N,A,C=null,I=null,L=!1,P=[],M=!1,k=!0,x=[],F=!1,U=!1,TK=null',
+  },
+  {
+    from: 'i(process.env.ZCALL_WINE||"wine",[o.join(__dirname,"..","native","qt-call-and-cap","pipebridge.exe"),"29631","29632"]),A=i(process.env.ZCALL_WINE||"wine"',
+    to: 'TK="zcall-"+Math.random().toString(36).slice(2)+Date.now().toString(36),i(process.env.ZCALL_WINE||"wine",[o.join(__dirname,"..","native","qt-call-and-cap","pipebridge.exe"),"29631","29632",TK]),A=i(process.env.ZCALL_WINE||"wine"',
+  },
+  {
+    from: 'e.on("data",(e=>{z(e)})),e.on("end"',
+    to: 'e.on("data",(n=>{if(!e.t){e.t=!0;const t=n.toString();if(t.indexOf(TK)!==0)return e.destroy();n=t.slice(TK.length+1)}z(n)})),e.on("end"',
+  },
+  {
+    from: 'e.on("data",(t=>{d.zsymb(4,"VafRm1",["serverSend on data","ySFwkp"],t),y||(F=!1,W(e))}))',
+    to: 'e.on("data",(t=>{if(!e.t){e.t=!0;const i=t.toString();if(i.indexOf(TK)!==0)return e.destroy();t=i.slice(TK.length+1)}d.zsymb(4,"VafRm1",["serverSend on data","ySFwkp"],t),y||(F=!1,W(e))}))',
+  },
+];
+
+async function main() {
+  if (!fs.existsSync(MAIN_JS)) {
+    logger.warn('main.js not found, skipping call-v2 patch');
+    return;
+  }
+
+  let content = fs.readFileSync(MAIN_JS, 'utf8');
+  let applied = 0;
+
+  for (const { from, to } of REPLACEMENTS) {
+    if (content.includes(to)) {
+      logger.dim('call-v2 patch already applied: ' + to.slice(0, 50) + '...');
+      applied++;
+      continue;
+    }
+    const count = content.split(from).length - 1;
+    if (count === 0) {
+      logger.warn('call-v2 pattern not found: ' + from.slice(0, 60) + '...');
+      continue;
+    }
+    content = content.split(from).join(to);
+    applied += count;
+    logger.dim(`call-v2 patched (x${count}): ${from.slice(0, 60)}...`);
+  }
+
+  if (applied > 0) {
+    fs.writeFileSync(MAIN_JS, content, 'utf8');
+    logger.success('zcall call-v2 patch applied');
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { main };

--- a/scripts/patches/patch-zcall-callv2.js
+++ b/scripts/patches/patch-zcall-callv2.js
@@ -91,6 +91,13 @@ const REPLACEMENTS = [
     from: 'let S,D,O,N,A,C=null,I=null,L=!1,P=[],M=!1,k=!0,x=[],F=!1,U=!1',
     to: 'let S,D,O,N,A,C=null,I=null,L=!1,P=[],M=!1,k=!0,x=[],F=!1,U=!1,TK=null',
   },
+  // 9. Reset the "native started" flag when the helper spawn FAILS (e.g.
+  //    wine missing). Without this, a failed first spawn leaves L=true
+  //    forever and later call attempts never re-spawn until app restart.
+  {
+    from: 'A.on("error",(e=>{d.zsymb(22,"4OM2ud",["client error","6Br8Rv"],e)}))',
+    to: 'A.on("error",(e=>{L=!1,d.zsymb(22,"4OM2ud",["client error","6Br8Rv"],e)}))',
+  },
   {
     from: 'i(process.env.ZCALL_WINE||"wine",[o.join(__dirname,"..","native","qt-call-and-cap","pipebridge.exe"),"29631","29632"]),A=i(process.env.ZCALL_WINE||"wine"',
     to: 'TK="zcall-"+Math.random().toString(36).slice(2)+Date.now().toString(36),i(process.env.ZCALL_WINE||"wine",[o.join(__dirname,"..","native","qt-call-and-cap","pipebridge.exe"),"29631","29632",TK]),A=i(process.env.ZCALL_WINE||"wine"',

--- a/scripts/patches/patch-zcall-callv2.js
+++ b/scripts/patches/patch-zcall-callv2.js
@@ -44,10 +44,14 @@ const REPLACEMENTS = [
     from: 'e=o.join(e,"Contents","MacOS","ZaloCall")),e}();',
     to: 'e=o.join(e,"Contents","MacOS","ZaloCall"))),e}();',
   },
-  // 3. spawn: on Linux, start pipebridge then ZaloCall under Wine
+  // 3. spawn: on Linux, start pipebridge then ZaloCall under Wine.
+  //    NOTE: `from` is anchored with the leading `;` so it cannot re-match
+  //    inside this replacement's own else branch (which keeps the original
+  //    text) — without the anchor, every re-run of the patch script nests
+  //    another dead linux branch into the ternary.
   {
-    from: 'A=i(e,[v,g]),A.stdout.setEncoding("utf8")',
-    to: '"linux"===process.platform?(i(process.env.ZCALL_WINE||"wine",[o.join(__dirname,"..","native","qt-call-and-cap","pipebridge.exe"),"29631","29632"]),A=i(process.env.ZCALL_WINE||"wine",[e,"\\\\\\\\.\\\\pipe\\\\PipeZCallRecv","\\\\\\\\.\\\\pipe\\\\PipeZCallSend"])):A=i(e,[v,g]),A.stdout.setEncoding("utf8")',
+    from: ';A=i(e,[v,g]),A.stdout.setEncoding("utf8")',
+    to: ';"linux"===process.platform?(i(process.env.ZCALL_WINE||"wine",[o.join(__dirname,"..","native","qt-call-and-cap","pipebridge.exe"),"29631","29632"]),A=i(process.env.ZCALL_WINE||"wine",[e,"\\\\\\\\.\\\\pipe\\\\PipeZCallRecv","\\\\\\\\.\\\\pipe\\\\PipeZCallSend"])):A=i(e,[v,g]),A.stdout.setEncoding("utf8")',
   },
   // 4. listen: TCP on Linux, unix socket elsewhere
   {
@@ -102,6 +106,13 @@ const REPLACEMENTS = [
     from: 'i(process.env.ZCALL_WINE||"wine",[o.join(__dirname,"..","native","qt-call-and-cap","pipebridge.exe"),"29631","29632"]),A=i(process.env.ZCALL_WINE||"wine"',
     to: 'TK="zcall-"+Math.random().toString(36).slice(2)+Date.now().toString(36),i(process.env.ZCALL_WINE||"wine",[o.join(__dirname,"..","native","qt-call-and-cap","pipebridge.exe"),"29631","29632",TK]),A=i(process.env.ZCALL_WINE||"wine"',
   },
+  // 10. Wayland screen-share bridge: preload the streamproxy shim (when the
+  //     plugin set ZCALL_PROXY_SO) so ZaloCall's screen-capture reads are
+  //     served from the bridge display while the app itself stays native.
+  {
+    from: '[e,"\\\\\\\\.\\\\pipe\\\\PipeZCallRecv","\\\\\\\\.\\\\pipe\\\\PipeZCallSend"]))',
+    to: '[e,"\\\\\\\\.\\\\pipe\\\\PipeZCallRecv","\\\\\\\\.\\\\pipe\\\\PipeZCallSend"],{env:Object.assign({},process.env,{LD_PRELOAD:process.env.ZCALL_PROXY_SO||process.env.LD_PRELOAD||""})}))',
+  },
   {
     from: 'e.on("data",(e=>{z(e)})),e.on("end"',
     to: 'e.on("data",(n=>{if(!e.t){e.t=!0;const t=n.toString();if(t.indexOf(TK)!==0)return e.destroy();n=t.slice(TK.length+1)}z(n)})),e.on("end"',
@@ -109,6 +120,43 @@ const REPLACEMENTS = [
   {
     from: 'e.on("data",(t=>{d.zsymb(4,"VafRm1",["serverSend on data","ySFwkp"],t),y||(F=!1,W(e))}))',
     to: 'e.on("data",(t=>{if(!e.t){e.t=!0;const i=t.toString();if(i.indexOf(TK)!==0)return e.destroy();t=i.slice(TK.length+1)}d.zsymb(4,"VafRm1",["serverSend on data","ySFwkp"],t),y||(F=!1,W(e))}))',
+  },
+  // 11. Helper restart support. The Wayland screen bridge restarts ZaloCall
+  //     mid-session (DISPLAY is read at spawn time), so the helper must be
+  //     able to die and come back: reset L on exit, and spawn pipebridge
+  //     (which owns the auth token) only ONCE per session — pipebridge
+  //     re-creates the pipes itself and waits for the next ZaloCall.
+  //     (BB, not B: the module already declares B.)
+  {
+    from: 'F=!1,U=!1,TK=null',
+    to: 'F=!1,U=!1,TK=null,BB=!1',
+  },
+  {
+    from: 'TK="zcall-"+Math.random().toString(36).slice(2)+Date.now().toString(36),i(process.env.ZCALL_WINE||"wine",[o.join(__dirname,"..","native","qt-call-and-cap","pipebridge.exe"),"29631","29632",TK]),A=i(process.env.ZCALL_WINE||"wine"',
+    to: 'BB||(BB=!0,TK="zcall-"+Math.random().toString(36).slice(2)+Date.now().toString(36),i(process.env.ZCALL_WINE||"wine",[o.join(__dirname,"..","native","qt-call-and-cap","pipebridge.exe"),"29631","29632",TK])),A=i(process.env.ZCALL_WINE||"wine"',
+  },
+  {
+    from: 'A.on("error",(e=>{L=!1,d.zsymb(22,"4OM2ud",["client error","6Br8Rv"],e)}))',
+    to: 'A.on("error",(e=>{L=!1,d.zsymb(22,"4OM2ud",["client error","6Br8Rv"],e)})),A.on("exit",(()=>{L=!1}))',
+  },
+  // 12. Queue sends while the helper is restarting instead of writing to a
+  //     destroyed socket (unhandled socket error would crash the main
+  //     process). The queue is flushed when pipebridge reconnects (token
+  //     line below) or after each helper message.
+  {
+    from: 'D=t=>{y?V(e,t):G(e,t)',
+    // No trailing `}`: D is the last statement of the connection callback
+    // and the original `}}))` closes D, the callback and C.on( — adding a
+    // brace here breaks the bundle syntax.
+    to: 'D=t=>{y?V(e,t):e&&!e.destroyed?G(e,t):x.push(t)',
+  },
+  {
+    from: 't=i.slice(TK.length+1)}d.zsymb(4,"VafRm1",["serverSend on data","ySFwkp"],t),y||(F=!1,W(e))',
+    to: 't=i.slice(TK.length+1)}W(e),d.zsymb(4,"VafRm1",["serverSend on data","ySFwkp"],t),y||(F=!1,W(e))',
+  },
+  {
+    from: 'else if(e){if(x.length){const t=x.shift();$(e,t)',
+    to: 'else if(e&&!e.destroyed){if(x.length){const t=x.shift();$(e,t)',
   },
 ];
 

--- a/scripts/prepare-app.js
+++ b/scripts/prepare-app.js
@@ -178,6 +178,12 @@ async function extractAppAsar() {
   const { main: patchZjxl } = require('./patches/patch-zjxl');
   await patchZjxl();
 
+  const { main: patchZcallCallgate } = require('./patches/patch-zcall-callgate');
+  await patchZcallCallgate();
+
+  const { main: patchZcallCallv2 } = require('./patches/patch-zcall-callv2');
+  await patchZcallCallv2();
+
   // const { main: patchFixImageResizeLinux } = require('./patches/patch-fix-image-resize-linux');
   // await patchFixImageResizeLinux();
 

--- a/scripts/setup-zcall-bridge.js
+++ b/scripts/setup-zcall-bridge.js
@@ -165,7 +165,7 @@ async function main() {
     } catch (e) {
       throw new Error(
         '32-bit build toolchain is required for streamproxy.so — ' +
-        'install with: sudo apt install gcc-multilib libc6-dev-i386 libx11-dev:i386 libxcb1-dev:i386' +
+        'install with: sudo apt install gcc-multilib libc6-dev-i386 libx11-dev:i386 libxcb1-dev:i386 libxext-dev:i386' +
         ' (gcc said: ' + String(e.stderr || e.message).trim().slice(-300) + ')'
       );
     }

--- a/scripts/setup-zcall-bridge.js
+++ b/scripts/setup-zcall-bridge.js
@@ -165,7 +165,8 @@ async function main() {
     } catch (e) {
       throw new Error(
         '32-bit build toolchain is required for streamproxy.so — ' +
-        'install with: sudo apt install gcc-multilib libx11-dev:i386 libxcb1-dev:i386'
+        'install with: sudo apt install gcc-multilib libc6-dev-i386 libx11-dev:i386 libxcb1-dev:i386' +
+        ' (gcc said: ' + String(e.stderr || e.message).trim().slice(-300) + ')'
       );
     }
   } else {

--- a/scripts/setup-zcall-bridge.js
+++ b/scripts/setup-zcall-bridge.js
@@ -8,6 +8,8 @@
  *      app/native/qt-call-and-cap/, then trims unneeded files
  *   2. Compiles pipebridge.c (252KB named-pipe <-> TCP pump, no runtime
  *      needed) with mingw, falling back to the committed prebuilt exe
+ *   3. Compiles streamproxy.c (LD_PRELOAD shim that redirects ZaloCall's
+ *      screen-capture reads to the Wayland bridge display) with gcc
  *
  * No proprietary binaries are committed to this repository — everything is
  * fetched from official sources at setup time (same policy as the macOS DMG).
@@ -144,6 +146,30 @@ async function main() {
     logger.success('pipebridge.exe installed');
   } else {
     logger.warn('pipebridge.exe missing — build it with: i686-w64-mingw32-gcc zcall-bridge/pipebridge.c -lws2_32 -O2 -o zcall-bridge/pipebridge.exe');
+  }
+
+  // -------------------------------------------------------------------------
+  // 3. streamproxy.so (LD_PRELOAD shim that redirects ZaloCall's
+  //    screen-capture reads to the bridge display). MUST be 32-bit: ZaloCall
+  //    is a 32-bit app, so its winex11 driver binds the 32-bit libX11 —
+  //    a 64-bit shim would never intercept anything.
+  // -------------------------------------------------------------------------
+  const proxySrc = path.join(ROOT, 'zcall-bridge', 'streamproxy.c');
+  const proxySo = path.join(ROOT, 'zcall-bridge', 'streamproxy.so');
+  if (fs.existsSync(proxySrc)) {
+    try {
+      execSync(`gcc -m32 -shared -fPIC -O2 "${proxySrc}" -ldl -lX11 -lxcb -o "${proxySo}"`, {
+        cwd: ROOT, stdio: 'pipe'
+      });
+      logger.dim('streamproxy.so (32-bit) compiled from source');
+    } catch (e) {
+      throw new Error(
+        '32-bit build toolchain is required for streamproxy.so — ' +
+        'install with: sudo apt install gcc-multilib libx11-dev:i386 libxcb1-dev:i386'
+      );
+    }
+  } else {
+    logger.warn('streamproxy.c missing — share screen will not work on Wayland');
   }
 
   logger.success('call-v2 runtime ready: ' + TARGET);

--- a/scripts/setup-zcall-bridge.js
+++ b/scripts/setup-zcall-bridge.js
@@ -14,7 +14,7 @@
  */
 
 const { execSync } = require('child_process');
-const fs = require('fs');
+const fs = require('fs-extra');
 const path = require('path');
 const https = require('https');
 const logger = require('./utils/logger');
@@ -116,9 +116,10 @@ async function main() {
   logger.dim('Trimmed unneeded Qt plugins / DLLs');
 
   // -------------------------------------------------------------------------
-  // 2. pipebridge.exe (tiny C named-pipe <-> TCP pump, no runtime needed)
-  //    Prefer compiling from source with mingw; fall back to the committed
-  //    prebuilt exe (our own code, reproducible from zcall-bridge/pipebridge.c).
+  // 2. pipebridge.exe (tiny C named-pipe <-> TCP pump, no runtime needed).
+  //    Compiled from source — requires mingw on the build machine
+  //    (i686-w64-mingw32-gcc). Binaries are not committed (*.exe is
+  //    gitignored per repo policy).
   // -------------------------------------------------------------------------
   const srcC = path.join(ROOT, 'zcall-bridge', 'pipebridge.c');
   const builtExe = path.join(ROOT, 'zcall-bridge', 'pipebridge.exe');
@@ -129,7 +130,10 @@ async function main() {
       });
       logger.dim('pipebridge.exe compiled from source');
     } catch (e) {
-      logger.warn('mingw compile failed, using committed prebuilt exe if present');
+      throw new Error(
+        'mingw (i686-w64-mingw32-gcc) is required to build pipebridge.exe — ' +
+        'install it with: sudo apt install gcc-mingw-w64-i686'
+      );
     }
   }
   if (fs.existsSync(builtExe)) {

--- a/scripts/setup-zcall-bridge.js
+++ b/scripts/setup-zcall-bridge.js
@@ -74,8 +74,10 @@ async function main() {
 
   // -------------------------------------------------------------------------
   // 1. plugins/capture from the Windows installer
+  //    NOTE: the Windows version is resolved independently of ZALO_VERSION
+  //    (which refers to the macOS DMG) — the two version families can diverge.
   // -------------------------------------------------------------------------
-  const version = process.env.ZALO_VERSION || await getWindowsVersion();
+  const version = process.env.ZALO_WIN_VERSION || await getWindowsVersion();
   logger.info(`Setting up call-v2 runtime from Zalo Windows v${version}...`);
 
   const exeName = `ZaloSetup-${version}.exe`;
@@ -92,7 +94,8 @@ async function main() {
     fs.copyFileSync(path.join(TEMP_DIR, 'zcall-bridge-extract', 'app-32.7z'), inner7z);
   }
 
-  const captureOut = path.join(TEMP_DIR, 'capture-extract');
+  // version-tagged so CI caching never serves a stale engine for a new version
+  const captureOut = path.join(TEMP_DIR, `capture-extract-${version}`);
   if (!fs.existsSync(path.join(captureOut, 'ZaloCall.exe'))) {
     sevenz(`x -y "${path.basename(inner7z)}" 'Zalo-${version}/plugins/capture/*' -o${captureOut}`);
   }

--- a/scripts/setup-zcall-bridge.js
+++ b/scripts/setup-zcall-bridge.js
@@ -1,0 +1,152 @@
+/**
+ * setup-zcall-bridge.js
+ *
+ * Prepares the call-v2 Wine runtime:
+ *
+ *   1. Downloads the official Windows Zalo installer and extracts
+ *      plugins/capture/ (ZaloCall.exe + Qt DLLs + plugins) into
+ *      app/native/qt-call-and-cap/, then trims unneeded files
+ *   2. Compiles pipebridge.c (252KB named-pipe <-> TCP pump, no runtime
+ *      needed) with mingw, falling back to the committed prebuilt exe
+ *
+ * No proprietary binaries are committed to this repository — everything is
+ * fetched from official sources at setup time (same policy as the macOS DMG).
+ */
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+const logger = require('./utils/logger');
+
+const ROOT = path.join(__dirname, '..');
+const TARGET = path.join(ROOT, 'app', 'native', 'qt-call-and-cap');
+const TEMP_DIR = path.join(ROOT, 'temp');
+
+const ZALO_WIN_PATTERN = 'https://res-download-pc.zadn.vn/win/ZaloSetup-VERSION.exe';
+
+function download(url, dest) {
+  return new Promise((resolve, reject) => {
+    const file = fs.createWriteStream(dest);
+    https.get(url, (res) => {
+      if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+        file.close();
+        return download(res.headers.location, dest).then(resolve, reject);
+      }
+      if (res.statusCode !== 200) {
+        file.close();
+        fs.unlinkSync(dest);
+        reject(new Error('HTTP ' + res.statusCode + ' for ' + url));
+        return;
+      }
+      res.pipe(file);
+      file.on('finish', () => { file.close(); resolve(); });
+    }).on('error', (e) => {
+      file.close();
+      try { fs.unlinkSync(dest); } catch (_) { /* ignore */ }
+      reject(e);
+    });
+  });
+}
+
+async function getWindowsVersion() {
+  return new Promise((resolve, reject) => {
+    https.get('https://zalo.me/download/zalo-pc?utm=90000', {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+      }
+    }, (res) => {
+      if (res.statusCode === 302 && res.headers.location) {
+        const m = res.headers.location.match(/ZaloSetup-([0-9.]+)\.exe/);
+        if (m) return resolve(m[1]);
+      }
+      reject(new Error('Could not resolve Windows Zalo version'));
+    }).on('error', reject);
+  });
+}
+
+function sevenz(args) {
+  execSync(`7z ${args}`, { cwd: TEMP_DIR, stdio: 'pipe' });
+}
+
+async function main() {
+  fs.ensureDirSync(TEMP_DIR);
+
+  // -------------------------------------------------------------------------
+  // 1. plugins/capture from the Windows installer
+  // -------------------------------------------------------------------------
+  const version = process.env.ZALO_VERSION || await getWindowsVersion();
+  logger.info(`Setting up call-v2 runtime from Zalo Windows v${version}...`);
+
+  const exeName = `ZaloSetup-${version}.exe`;
+  const exePath = path.join(TEMP_DIR, exeName);
+  if (!fs.existsSync(exePath)) {
+    logger.dim('Downloading Windows installer...');
+    await download(ZALO_WIN_PATTERN.replace('VERSION', version), exePath);
+  }
+
+  const inner7z = path.join(TEMP_DIR, `zcall-bridge-${version}.7z`);
+  if (!fs.existsSync(inner7z)) {
+    logger.dim('Extracting installer payload...');
+    sevenz(`e -y "${exeName}" '$PLUGINSDIR/app-32.7z' -ozcall-bridge-extract`);
+    fs.copyFileSync(path.join(TEMP_DIR, 'zcall-bridge-extract', 'app-32.7z'), inner7z);
+  }
+
+  const captureOut = path.join(TEMP_DIR, 'capture-extract');
+  if (!fs.existsSync(path.join(captureOut, 'ZaloCall.exe'))) {
+    sevenz(`x -y "${path.basename(inner7z)}" 'Zalo-${version}/plugins/capture/*' -o${captureOut}`);
+  }
+
+  const captureSrc = path.join(captureOut, `Zalo-${version}`, 'plugins', 'capture');
+  fs.ensureDirSync(TARGET);
+  fs.copySync(captureSrc, TARGET, { overwrite: true });
+  logger.success('ZaloCall.exe + Qt runtime installed');
+
+  // Trim the capture folder: keep only what ZaloCall.exe needs.
+  // Verified by replay tests: 1-1 calls work without these.
+  for (const junk of ['pdbs', 'translations', 'bearer', 'iconengines',
+                      'playlistformats', 'sqldrivers', 'styles']) {
+    fs.removeSync(path.join(TARGET, junk));
+  }
+  for (const junkFile of ['opengl32sw.dll',  // Qt software-GL fallback (unused under Wine)
+                          'Qt5Sql.dll', 'Qt5Xml.dll']) {
+    fs.removeSync(path.join(TARGET, junkFile));
+  }
+  // Note: ZaviMeet.exe (19MB) is KEPT — required for group video calls.
+  logger.dim('Trimmed unneeded Qt plugins / DLLs');
+
+  // -------------------------------------------------------------------------
+  // 2. pipebridge.exe (tiny C named-pipe <-> TCP pump, no runtime needed)
+  //    Prefer compiling from source with mingw; fall back to the committed
+  //    prebuilt exe (our own code, reproducible from zcall-bridge/pipebridge.c).
+  // -------------------------------------------------------------------------
+  const srcC = path.join(ROOT, 'zcall-bridge', 'pipebridge.c');
+  const builtExe = path.join(ROOT, 'zcall-bridge', 'pipebridge.exe');
+  if (fs.existsSync(srcC)) {
+    try {
+      execSync(`i686-w64-mingw32-gcc "${srcC}" -lws2_32 -O2 -o "${builtExe}"`, {
+        cwd: ROOT, stdio: 'pipe'
+      });
+      logger.dim('pipebridge.exe compiled from source');
+    } catch (e) {
+      logger.warn('mingw compile failed, using committed prebuilt exe if present');
+    }
+  }
+  if (fs.existsSync(builtExe)) {
+    fs.copyFileSync(builtExe, path.join(TARGET, 'pipebridge.exe'));
+    logger.success('pipebridge.exe installed');
+  } else {
+    logger.warn('pipebridge.exe missing — build it with: i686-w64-mingw32-gcc zcall-bridge/pipebridge.c -lws2_32 -O2 -o zcall-bridge/pipebridge.exe');
+  }
+
+  logger.success('call-v2 runtime ready: ' + TARGET);
+}
+
+if (require.main === module) {
+  main().catch((e) => {
+    logger.error('Setup failed:', e.message);
+    process.exit(1);
+  });
+}
+
+module.exports = { main };

--- a/zcall-bridge/.gitignore
+++ b/zcall-bridge/.gitignore
@@ -1,0 +1,2 @@
+pycache
+streamproxy.so

--- a/zcall-bridge/README.md
+++ b/zcall-bridge/README.md
@@ -83,13 +83,18 @@ Người dùng nâng cao có thể chỉ định wine riêng. Khi app khởi đ�
 tự dò theo thứ tự ưu tiên:
 
 ```
-1. Biến môi trường ZCALL_WINE          ← ưu tiên cao nhất
-2. Wine đã tải tự động (mục trên)      ← <userData>/zcall-wine-runtime/bin/wine
-3. Lệnh `wine` trong PATH              ← wine hệ thống (apt install wine...)
+1. Biến môi trường ZCALL_WINE          ← ưu tiên cao nhất (user tự chỉ định)
+2. Wine đã tải tự động                ← <userData>/zcall-wine-runtime/bin/wine
+                                          (bản app kiểm soát + đã test — nên
+                                          dùng để có trải nghiệm đồng nhất)
+3. Lệnh `wine` trong PATH              ← wine hệ thống (apt/dnf install wine...)
 4. Runner Bottles (flatpak)            ← ~/.var/app/com.usebottles.bottles/
                                           data/bottles/runners/kron4ek-wine-*/
                                           bin/wine (chọn bản mới nhất)
 ```
+
+App thử lần lượt từng ứng viên và chọn bản đầu tiên **chạy được app 32-bit**;
+wine hỏng tự động bỏ qua sang bản tiếp theo.
 
 Nếu không tìm thấy wine: app vẫn chạy bình thường, chỉ **không có tính năng
 gọi** — và hộp thoại hỏi tải wine ở trên sẽ xuất hiện.
@@ -104,9 +109,30 @@ gọi** — và hộp thoại hỏi tải wine ở trên sẽ xuất hiện.
 | `ZCALL_AUTO_SETUP` | `'1'` = tải wine tự động, không hỏi (dùng khi triển khai hàng loạt/script) | — |
 | `ZCALL_WINE_DOWNLOAD_URL` | Ghi đè URL tải wine portable | URL kron4ek 11.14 trên GitHub |
 
-> ⚠️ Wine cần hỗ trợ chạy app 32-bit (ZaloCall.exe là PE32). Các bản Wine 8+
-> có chế độ wow64 chạy được 32-bit trên wine64 thuần; bản cũ hơn cần
-> `dpkg --add-architecture i386` + gói wine32.
+> ⚠️ Wine cần hỗ trợ chạy app 32-bit (ZaloCall.exe là PE32). Bản wine tải
+> tự động (kron4ek classic) dùng loader 32-bit nên **máy cần thư viện 32-bit**.
+> App tự phát hiện và hiện dialog hướng dẫn đúng distro khi thiếu:
+>
+> **Ubuntu/Debian:**
+> ```bash
+> sudo dpkg --add-architecture i386 && sudo apt update
+> sudo apt install -y libc6:i386 libx11-6:i386 libfreetype6:i386 libgl1:i386 libpulse0:i386 zlib1g:i386
+> ```
+> **Fedora/RHEL:**
+> ```bash
+> sudo dnf install -y glibc.i686 libX11.i686 libXext.i686 freetype.i686 mesa-libGL.i686 pulseaudio-libs.i686 zlib-ng-compat.i686 gstreamer1.i686 gstreamer1-plugins-base.i686 gstreamer1-plugins-good.i686 gstreamer1-plugins-bad-free.i686
+> ```
+> (GStreamer 32-bit cần cho video call — nếu thiếu, video call crash trong winegstreamer.
+> `gstreamer1-plugin-libav.i686` để decode H.264 cần RPM Fusion:
+> `sudo dnf install https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm` rồi `sudo dnf install gstreamer1-plugin-libav.i686`)
+> **Arch:**
+> ```bash
+> sudo pacman -S --needed lib32-glibc lib32-libx11 lib32-libxext lib32-freetype2 lib32-mesa lib32-libpulse lib32-zlib
+> ```
+> (hoặc cài wine hệ thống — `apt install wine` / `dnf install wine` /
+> `pacman -S wine` — tự kéo đủ thư viện).
+> Lưu ý: bản kron4ek **wow64** (thuần 64-bit) đã thử — không chạy được
+> ZaloCall (wow64 thử nghiệm lỗi với Qt 32-bit), nên không dùng.
 
 ### Ví dụ chạy với wine tự chọn
 

--- a/zcall-bridge/README.md
+++ b/zcall-bridge/README.md
@@ -217,11 +217,15 @@ v4l2-ctl --set-fmt-video=width=640,height=480,pixelformat=MJPG
 Trên Wayland, XWayland không nhìn thấy desktop nên ZaloCall (wine) chụp được
 màn hình đen. App có sẵn **bridge riêng**:
 
-1. Cài thành phần (một lần):
+1. Cài thành phần (một lần — nếu thiếu, app tự hiện dialog với đúng lệnh cho
+   distro của bạn khi bấm Share screen):
    ```bash
-   # Fedora:  sudo dnf install xorg-x11-server-Xvfb xdotool python3-dbus
-   # Ubuntu:  sudo apt install xvfb xdotool python3-dbus
-   # Arch:    sudo pacman -S xorg-server-xvfb xdotool python-dbus
+   # Fedora:  sudo dnf install xorg-x11-server-Xvfb xdotool python3-dbus \
+   #            gstreamer1-plugins-base gstreamer1-plugins-bad-free
+   # Ubuntu:  sudo apt install xvfb xdotool python3-dbus \
+   #            gstreamer1.0-plugins-base gstreamer1.0-plugins-bad
+   # Arch:    sudo pacman -S xorg-server-xvfb xdotool python-dbus \
+   #            gst-plugins-base gst-plugins-bad
    ```
    (`streamproxy.so` được build sẵn vào app — không cần cài gì thêm.)
 2. Gọi video **hoàn toàn như bình thường** — giao diện cuộc gọi là cửa sổ

--- a/zcall-bridge/README.md
+++ b/zcall-bridge/README.md
@@ -46,7 +46,9 @@ node scripts/setup-zcall-bridge.js
 - Tải installer Windows chính thức, tách `plugins/capture/` →
   `app/native/qt-call-and-cap/` (ZaloCall.exe + ZaviMeet.exe + Qt DLLs +
   plugins, sau khi tỉa còn ~67MB)
-- Compile `pipebridge.c` bằng mingw (fallback dùng exe đã commit)
+- Compile `pipebridge.c` bằng mingw — máy build cần
+  `gcc-mingw-w64-i686` (`sudo apt install gcc-mingw-w64-i686`); exe không
+  được commit theo chính sách repo (`*.exe` trong .gitignore)
 
 Yêu cầu: Wine chạy được 32-bit (wow64 như Wine 11). Khi app thoát, plugin
 kill toàn bộ phiên wine của prefix (`wineserver -k` + hard-kill
@@ -56,10 +58,14 @@ wineserver/winedevice còn sót).
 
 Người dùng **không cần cài gì thủ công**. Ngay lần mở app đầu tiên:
 
-1. Nếu máy chưa có wine, app hiện cửa sổ hỏi **luôn nổi trên cửa sổ chính**
-   (không bị che): *"Tính năng gọi điện cần Wine. Tải và bật ngay bây giờ?"*
-   — nút **"Tải và bật ngay"** / **"Để sau"**, kèm link nguồn tải minh bạch
-   và checkbox **"Không hỏi lại lần sau nếu không tải"**
+1. App **tự kiểm tra** wine tìm thấy có chạy được app 32-bit không (chạy thử
+   `pipebridge.exe --version` — chính là exe 32-bit của cầu nối):
+   - Wine hoạt động tốt → **dùng im lặng, không hiện dialog nào**
+   - Chưa có wine, hoặc wine có nhưng **không tương thích** (không hỗ trợ
+     32-bit / quá cũ) → hiện cửa sổ hỏi **luôn nổi trên cửa sổ chính**
+     (không bị che), kèm lý do cụ thể — nút **"Tải và bật ngay"** /
+     **"Để sau"**, link nguồn tải minh bạch và checkbox
+     **"Không hỏi lại lần sau nếu không tải"**
 2. Chọn tải → cửa sổ tiến trình *"Đang tải Wine (~54MB)…"* với % trực quan
    → tự giải nén → tự khởi tạo prefix (mất ~1-2 phút tổng cộng)
 3. Xong → thông báo *"Tính năng gọi điện đã sẵn sàng!"* — gọi được ngay,

--- a/zcall-bridge/README.md
+++ b/zcall-bridge/README.md
@@ -1,0 +1,177 @@
+# zcall-bridge — cuộc gọi Zalo trên Linux qua Wine
+
+Chạy engine gọi điện (voice/video) của Zalo trên Linux.
+
+## Vấn đề
+
+Zalo PC 26.x thực hiện cuộc gọi bằng helper **ZaloCall.exe** (app Qt, chỉ có
+bản Windows/macOS). Trên Linux không có helper tương ứng, và Wine ≥ 9.9 đã
+bỏ hỗ trợ AF_UNIX socket (nhánh macOS dùng unix socket).
+
+## Giải pháp
+
+Chạy **ZaloCall.exe bản Windows** dưới Wine, bắc cầu kênh giao tiếp bằng
+named pipes (thứ Wine hỗ trợ tốt):
+
+```
+┌── Zalo app (Linux, đã patch) ────────────────────────────────┐
+│  main process: listen TCP 127.0.0.1:29631 (recv) / 29632 (send)
+│  spawn: wine pipebridge.exe 29631 29632
+│  spawn: wine ZaloCall.exe \\.\pipe\PipeZCallRecv \\.\pipe\PipeZCallSend
+└──────────────┬───────────────────────────────────────────────┘
+               │ TCP loopback
+┌──────────────▼───────────────────────────────────────────────┐
+│  WINE prefix                                                  │
+│  pipebridge.exe (C, 252KB, không cần runtime)                │
+│    named pipes ⇄ TCP, pump dữ liệu 2 chiều                   │
+│  ZaloCall.exe — engine gọi thật (Qt5)                        │
+└──────────────────────────────────────────────────────────────┘
+```
+
+Transport: AES-128-CBC (key cố định trong app), message JSON phân tách `$`.
+
+## Các patch (scripts/patches/)
+
+| Patch | Mục đích |
+|---|---|
+| `patch-zcall-callv2.js` | Nhánh Linux cho call-v2: TCP ports, spawn qua Wine + pipebridge, **gửi lại init trước mỗi makeCall** (chống lỗi -11 init_error), **fix cờ F kẹt queue gửi** của Zalo, bỏ qua unlink/verifyMd5 không áp dụng |
+| `patch-zcall-callgate.js` | Mở 2 gate UI: bỏ check `os.release() < 17` (viết cho Darwin kernel, trên Linux kernel 7.x luôn fail) và bật default `enableCall`/`enableVideoCall` |
+
+## Cài đặt
+
+```bash
+node scripts/setup-zcall-bridge.js
+```
+
+- Tải installer Windows chính thức, tách `plugins/capture/` →
+  `app/native/qt-call-and-cap/` (ZaloCall.exe + ZaviMeet.exe + Qt DLLs +
+  plugins, sau khi tỉa còn ~67MB)
+- Compile `pipebridge.c` bằng mingw (fallback dùng exe đã commit)
+
+Yêu cầu: Wine chạy được 32-bit (wow64 như Wine 11). Khi app thoát, plugin
+kill toàn bộ phiên wine của prefix (`wineserver -k` + hard-kill
+wineserver/winedevice còn sót).
+
+## Trải nghiệm người dùng: tự động cài wine
+
+Người dùng **không cần cài gì thủ công**. Ngay lần mở app đầu tiên:
+
+1. Nếu máy chưa có wine, app hiện cửa sổ hỏi **luôn nổi trên cửa sổ chính**
+   (không bị che): *"Tính năng gọi điện cần Wine. Tải và bật ngay bây giờ?"*
+   — nút **"Tải và bật ngay"** / **"Để sau"**, kèm link nguồn tải minh bạch
+   và checkbox **"Không hỏi lại lần sau nếu không tải"**
+2. Chọn tải → cửa sổ tiến trình *"Đang tải Wine (~54MB)…"* với % trực quan
+   → tự giải nén → tự khởi tạo prefix (mất ~1-2 phút tổng cộng)
+3. Xong → thông báo *"Tính năng gọi điện đã sẵn sàng!"* — gọi được ngay,
+   không cần khởi động lại, không cần quyền quản trị
+4. Chọn "Để sau" → **hỏi lại vào lần mở app sau**; tick "không hỏi lại" →
+   không bao giờ tự hỏi nữa. Cả hai trường hợp đều bật lại được qua
+   **menu khay hệ thống → "Cài đặt gọi điện…"**
+
+Wine tải về được lưu tại `<userData>/zcall-wine-runtime/` — hoàn toàn trong
+dữ liệu của app, không đụng hệ thống, gỡ app là sạch.
+
+## Cấu hình Wine (custom path)
+
+Người dùng nâng cao có thể chỉ định wine riêng. Khi app khởi động, plugin
+tự dò theo thứ tự ưu tiên:
+
+```
+1. Biến môi trường ZCALL_WINE          ← ưu tiên cao nhất
+2. Wine đã tải tự động (mục trên)      ← <userData>/zcall-wine-runtime/bin/wine
+3. Lệnh `wine` trong PATH              ← wine hệ thống (apt install wine...)
+4. Runner Bottles (flatpak)            ← ~/.var/app/com.usebottles.bottles/
+                                          data/bottles/runners/kron4ek-wine-*/
+                                          bin/wine (chọn bản mới nhất)
+```
+
+Nếu không tìm thấy wine: app vẫn chạy bình thường, chỉ **không có tính năng
+gọi** — và hộp thoại hỏi tải wine ở trên sẽ xuất hiện.
+
+### Các biến môi trường
+
+| Biến | Ý nghĩa | Mặc định |
+|---|---|---|
+| `ZCALL_WINE` | Đường dẫn tuyệt đối tới binary `wine` | tự dò (xem thứ tự trên) |
+| `ZCALL_WINEPREFIX` | Prefix wine dành riêng cho app | `<userData>/zcall-wine` |
+| `ZCALL_DISABLE` | Set bất kỳ giá trị nào để tắt hẳn tính năng gọi | — |
+| `ZCALL_AUTO_SETUP` | `'1'` = tải wine tự động, không hỏi (dùng khi triển khai hàng loạt/script) | — |
+| `ZCALL_WINE_DOWNLOAD_URL` | Ghi đè URL tải wine portable | URL kron4ek 11.14 trên GitHub |
+
+> ⚠️ Wine cần hỗ trợ chạy app 32-bit (ZaloCall.exe là PE32). Các bản Wine 8+
+> có chế độ wow64 chạy được 32-bit trên wine64 thuần; bản cũ hơn cần
+> `dpkg --add-architecture i386` + gói wine32.
+
+### Ví dụ chạy với wine tự chọn
+
+**Dev mode:**
+
+```bash
+# Wine hệ thống bạn tự cài (ví dụ apt install wine)
+ZCALL_WINE=/usr/bin/wine npm start
+
+# Wine build riêng tải từ internet
+ZCALL_WINE=/opt/wine-10.0/bin/wine npm start
+
+# Kèm prefix riêng
+ZCALL_WINE=/usr/bin/wine ZCALL_WINEPREFIX=~/zalo-call-prefix npm start
+
+# Tắt hẳn tính năng gọi
+ZCALL_DISABLE=1 npm start
+```
+
+**AppImage (bản đóng gói):**
+
+```bash
+# Chạy từ terminal, env áp dụng cho phiên đó
+ZCALL_WINE=/usr/bin/wine ./Zalo-<version>.AppImage
+```
+
+Muốn áp vĩnh viễn: sửa file `.desktop` của app (do Gear Lever/trình đơn tạo),
+thêm biến vào dòng `Exec`:
+
+```ini
+Exec=env ZCALL_WINE=/usr/bin/wine /đường/dẫn/tới/Zalo.AppImage
+```
+
+### Kiểm tra wine có chạy được không
+
+```bash
+# 1. Wine hoạt động?
+/đường/dẫn/wine --version          # in ra phiên bản, ví dụ wine-11.14
+
+# 2. Chạy được app 32-bit? (tạo prefix thử — lần đầu mất ~30s)
+WINEPREFIX=/tmp/test-prefix /đường/dẫn/wine wineboot -u
+ls /tmp/test-prefix/drive_c        # có Program Files/ = OK
+rm -rf /tmp/test-prefix
+
+# 3. Mở app với env, gọi thử một cuộc thoại. Lần gọi đầu tiên hơi chậm
+#    (wine khởi động nguội + tạo prefix nếu chưa có ~5-15s).
+```
+
+### Prefix nằm ở đâu
+
+- Mặc định: `<userData>/zcall-wine` — `userData` của app là
+  `~/.config/ZaloData/` (hoặc theo env `XDG_CONFIG_HOME`).
+- App **chỉ thao tác wine trong đúng prefix này** — không đụng tới
+  `~/.wine` hay các prefix Bottles khác của bạn.
+- Khi app thoát, toàn bộ tiến trình wine của prefix này bị dọn sạch
+  (`wineserver -k` + hard-kill `wineserver`/`winedevice.exe` còn sót).
+- Muốn reset trạng thái gọi: xóa thư mục prefix rồi mở lại app —
+  plugin sẽ tự tạo lại prefix mới.
+
+## Đã xác minh
+
+- ✅ ZaloCall.exe chạy dưới Wine (wow64), kết nối đủ 2 kênh. Các bản đã test
+  thật qua replay (init → makeCall → incall → success → sendSignal):
+  **11.14** (96MB/852MB), **8.6** (54MB/565MB — dùng làm mặc định tải tự
+  động), **8.0.1** (53MB/564MB), **7.22** (53MB/563MB)
+- ✅ `native-ready` → `init` → `makeCall` → `callState: incall`, `show success`,
+  `sendSignal 401` — engine thực hiện cuộc gọi thật (voice + video signaling)
+- ✅ **Người dùng xác nhận cuộc gọi thoại hoạt động** trong app
+- ✅ pipebridge C (252KB) hoạt động trong app thật
+- ✅ Thư mục engine đã tỉa 196MB → **67MB** (bỏ pdbs, translations, Qt plugins
+  thừa, opengl32sw, Qt5Sql/Xml; giữ ZaviMeet cho group call) — call 1-1 vẫn chạy
+- ✅ Tắt app → wine session được dọn sạch (wineserver + winedevice)
+- ⚠️ Chưa test: video call end-to-end (máy test không có webcam) — signaling
+  video đã chạy, cần máy có camera để xác nhận capture + hiển thị

--- a/zcall-bridge/README.md
+++ b/zcall-bridge/README.md
@@ -107,32 +107,102 @@ gọi** — và hộp thoại hỏi tải wine ở trên sẽ xuất hiện.
 | `ZCALL_WINEPREFIX` | Prefix wine dành riêng cho app | `<userData>/zcall-wine` |
 | `ZCALL_DISABLE` | Set bất kỳ giá trị nào để tắt hẳn tính năng gọi | — |
 | `ZCALL_AUTO_SETUP` | `'1'` = tải wine tự động, không hỏi (dùng khi triển khai hàng loạt/script) | — |
-| `ZCALL_WINE_DOWNLOAD_URL` | Ghi đè URL tải wine portable | URL kron4ek 8.6 trên GitHub |
+| `ZCALL_WINE_DOWNLOAD_URL` | Ghi đè URL tải wine portable | URL kron4ek 11.14 trên GitHub |
 
-> ⚠️ Wine cần hỗ trợ chạy app 32-bit (ZaloCall.exe là PE32). Bản wine tải
-> tự động (kron4ek classic) dùng loader 32-bit nên **máy cần thư viện 32-bit**.
-> App tự phát hiện và hiện dialog hướng dẫn đúng distro khi thiếu:
->
-> **Ubuntu/Debian:**
-> ```bash
-> sudo dpkg --add-architecture i386 && sudo apt update
-> sudo apt install -y libc6:i386 libx11-6:i386 libfreetype6:i386 libgl1:i386 libpulse0:i386 libasound2:i386 libv4l-0:i386 zlib1g:i386 libgstreamer1.0-0:i386 libgstreamer-plugins-base1.0-0:i386 gstreamer1.0-plugins-good:i386 gstreamer1.0-libav:i386
-> ```
-> **Fedora/RHEL:**
-> ```bash
-> sudo dnf install -y glibc.i686 libX11.i686 libXext.i686 freetype.i686 mesa-libGL.i686 pulseaudio-libs.i686 alsa-lib.i686 libv4l.i686 zlib-ng-compat.i686 gstreamer1.i686 gstreamer1-plugins-base.i686 gstreamer1-plugins-good.i686 gstreamer1-plugins-bad-free.i686
-> ```
-> (GStreamer 32-bit cần cho video call — nếu thiếu, video call crash trong winegstreamer.
-> `gstreamer1-plugin-libav.i686` để decode H.264 cần RPM Fusion:
-> `sudo dnf install https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm` rồi `sudo dnf install gstreamer1-plugin-libav.i686`)
-> **Arch:**
-> ```bash
-> sudo pacman -S --needed lib32-glibc lib32-libx11 lib32-libxext lib32-freetype2 lib32-mesa lib32-libpulse lib32-alsa-lib lib32-libv4l lib32-zlib lib32-gstreamer lib32-gst-plugins-base lib32-gst-plugins-good lib32-gst-libav
-> ```
-> (hoặc cài wine hệ thống — `apt install wine` / `dnf install wine` /
-> `pacman -S wine` — tự kéo đủ thư viện).
-> Lưu ý: bản kron4ek **wow64** (thuần 64-bit) đã thử — không chạy được
-> ZaloCall (wow64 thử nghiệm lỗi với Qt 32-bit), nên không dùng.
+## Cài thư viện cho từng distro (copy-paste)
+
+Bản wine tải tự động (kron4ek classic) dùng loader 32-bit nên **máy cần thư
+viện 32-bit**. Có 2 mức:
+
+- **Tối thiểu (gọi thoại — loa + mic)**: base libs + driver âm thanh
+- **Đầy đủ (thoại + video)**: thêm GStreamer + libv4l
+
+App cũng tự hiện dialog hướng dẫn đúng distro khi thiếu.
+
+### Ubuntu / Debian
+
+```bash
+sudo dpkg --add-architecture i386 && sudo apt update
+
+# Tối thiểu — gọi thoại
+sudo apt install -y libc6:i386 libx11-6:i386 libxext6:i386 libfreetype6:i386 \
+  libgl1:i386 libpulse0:i386 libasound2:i386 zlib1g:i386
+
+# Đầy đủ — thêm cho video call
+sudo apt install -y libgstreamer1.0-0:i386 libgstreamer-plugins-base1.0-0:i386 \
+  gstreamer1.0-plugins-good:i386 libv4l-0:i386
+
+# Khuyến nghị — decode H.264 video từ đầu bên kia
+sudo apt install -y gstreamer1.0-libav:i386
+```
+
+### Fedora / RHEL
+
+```bash
+# Tối thiểu — gọi thoại
+sudo dnf install -y glibc.i686 libX11.i686 libXext.i686 freetype.i686 \
+  mesa-libGL.i686 pulseaudio-libs.i686 alsa-lib.i686 zlib-ng-compat.i686
+
+# Đầy đủ — thêm cho video call
+sudo dnf install -y gstreamer1.i686 gstreamer1-plugins-base.i686 \
+  gstreamer1-plugins-good.i686 libv4l.i686
+
+# Khuyến nghị — decode H.264 (cần RPM Fusion)
+sudo dnf install https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm
+sudo dnf install gstreamer1-plugin-libav.i686
+```
+
+### Arch
+
+```bash
+# Tối thiểu — gọi thoại
+sudo pacman -S --needed lib32-glibc lib32-libx11 lib32-libxext \
+  lib32-freetype2 lib32-mesa lib32-libpulse lib32-alsa-lib lib32-zlib
+
+# Đầy đủ — thêm cho video call
+sudo pacman -S --needed lib32-gstreamer lib32-gst-plugins-base \
+  lib32-gst-plugins-good lib32-libv4l
+
+# Khuyến nghị — decode H.264
+sudo pacman -S --needed lib32-gst-libav
+```
+
+> `gstreamer1.0-plugins-bad` (Ubuntu) / `gstreamer1-plugins-bad-free` (Fedora)
+> chỉ cần khi không dùng libav — không bắt buộc nếu đã cài libav.
+
+### Đường tắt: cài wine hệ thống
+
+`sudo apt install wine` / `sudo dnf install wine` / `sudo pacman -S wine` —
+trình quản lý gói tự kéo đủ thư viện. App tự phát hiện và dùng wine hệ thống.
+
+### Kiểm tra sau khi cài
+
+```bash
+# Mic được hệ thống nhận chưa?
+pactl list sources short | grep -i input
+# Loa?
+pactl list sinks short
+# Camera?
+ls /dev/video*          # rỗng = chưa nhận phần cứng; thiếu quyền: sudo usermod -aG video $USER
+```
+
+### Camera bị xanh/nhòe (lệch định dạng pixel)
+
+Cài công cụ điều khiển camera (`sudo apt install v4l-utils` /
+`sudo dnf install v4l-utils` / `sudo pacman -S v4l-utils`) rồi ép format:
+
+```bash
+v4l2-ctl --set-fmt-video=width=640,height=480,pixelformat=MJPG
+```
+
+(hết hiệu lực khi rút cắm camera)
+
+### Lưu ý giới hạn
+
+- Bản kron4ek **wow64** (thuần 64-bit) không chạy được ZaloCall — không dùng.
+- **Share screen chỉ hoạt động trên phiên X11** (GNOME on Xorg / Plasma X11);
+  trên Wayland, XWayland không nhìn thấy desktop nên màn hình chia sẻ trống —
+  giới hạn chung của Wine trên Wayland, không có cách xử lý từ phía app.
 
 ### Ví dụ chạy với wine tự chọn
 

--- a/zcall-bridge/README.md
+++ b/zcall-bridge/README.md
@@ -77,6 +77,18 @@ Người dùng **không cần cài gì thủ công**. Ngay lần mở app đầu
 Wine tải về được lưu tại `<userData>/zcall-wine-runtime/` — hoàn toàn trong
 dữ liệu của app, không đụng hệ thống, gỡ app là sạch.
 
+### Biến thể Full (wine đi kèm sẵn)
+
+Release có 2 biến thể **Full** (~430MB) cho cả 2 flavor: portable wine
+được đóng gói sẵn **bên trong AppImage** (`app/native/wine-runtime/`):
+
+- `Zalo-<ver>-<hash>-Full.AppImage` — không ZaDark
+- `Zalo-<ver>+ZaDark-<zdv>-<hash>-Full.AppImage` — có ZaDark
+
+Mở app lần đầu là gọi được ngay — không cần mạng, không cần tải wine.
+Bản thường (~263MB) vẫn giữ luồng tự tải ở trên; tất cả chạy từ cùng
+một code, chỉ khác phần wine đi kèm.
+
 ## Cấu hình Wine (custom path)
 
 Người dùng nâng cao có thể chỉ định wine riêng. Khi app khởi động, plugin
@@ -84,11 +96,14 @@ tự dò theo thứ tự ưu tiên:
 
 ```
 1. Biến môi trường ZCALL_WINE          ← ưu tiên cao nhất (user tự chỉ định)
-2. Wine đã tải tự động                ← <userData>/zcall-wine-runtime/bin/wine
+2. Wine đi kèm app (biến thể Full)    ← app/native/wine-runtime/bin/wine
+                                          trong AppImage — mở là dùng được
+                                          ngay, không cần tải gì thêm
+3. Wine đã tải tự động                ← <userData>/zcall-wine-runtime/bin/wine
                                           (bản app kiểm soát + đã test — nên
                                           dùng để có trải nghiệm đồng nhất)
-3. Lệnh `wine` trong PATH              ← wine hệ thống (apt/dnf install wine...)
-4. Runner Bottles (flatpak)            ← ~/.var/app/com.usebottles.bottles/
+4. Lệnh `wine` trong PATH              ← wine hệ thống (apt/dnf install wine...)
+5. Runner Bottles (flatpak)            ← ~/.var/app/com.usebottles.bottles/
                                           data/bottles/runners/kron4ek-wine-*/
                                           bin/wine (chọn bản mới nhất)
 ```

--- a/zcall-bridge/README.md
+++ b/zcall-bridge/README.md
@@ -107,7 +107,7 @@ gọi** — và hộp thoại hỏi tải wine ở trên sẽ xuất hiện.
 | `ZCALL_WINEPREFIX` | Prefix wine dành riêng cho app | `<userData>/zcall-wine` |
 | `ZCALL_DISABLE` | Set bất kỳ giá trị nào để tắt hẳn tính năng gọi | — |
 | `ZCALL_AUTO_SETUP` | `'1'` = tải wine tự động, không hỏi (dùng khi triển khai hàng loạt/script) | — |
-| `ZCALL_WINE_DOWNLOAD_URL` | Ghi đè URL tải wine portable | URL kron4ek 11.14 trên GitHub |
+| `ZCALL_WINE_DOWNLOAD_URL` | Ghi đè URL tải wine portable | URL kron4ek 8.6 trên GitHub |
 
 > ⚠️ Wine cần hỗ trợ chạy app 32-bit (ZaloCall.exe là PE32). Bản wine tải
 > tự động (kron4ek classic) dùng loader 32-bit nên **máy cần thư viện 32-bit**.
@@ -116,18 +116,18 @@ gọi** — và hộp thoại hỏi tải wine ở trên sẽ xuất hiện.
 > **Ubuntu/Debian:**
 > ```bash
 > sudo dpkg --add-architecture i386 && sudo apt update
-> sudo apt install -y libc6:i386 libx11-6:i386 libfreetype6:i386 libgl1:i386 libpulse0:i386 zlib1g:i386
+> sudo apt install -y libc6:i386 libx11-6:i386 libfreetype6:i386 libgl1:i386 libpulse0:i386 libasound2:i386 libv4l-0:i386 zlib1g:i386 libgstreamer1.0-0:i386 libgstreamer-plugins-base1.0-0:i386 gstreamer1.0-plugins-good:i386 gstreamer1.0-libav:i386
 > ```
 > **Fedora/RHEL:**
 > ```bash
-> sudo dnf install -y glibc.i686 libX11.i686 libXext.i686 freetype.i686 mesa-libGL.i686 pulseaudio-libs.i686 zlib-ng-compat.i686 gstreamer1.i686 gstreamer1-plugins-base.i686 gstreamer1-plugins-good.i686 gstreamer1-plugins-bad-free.i686
+> sudo dnf install -y glibc.i686 libX11.i686 libXext.i686 freetype.i686 mesa-libGL.i686 pulseaudio-libs.i686 alsa-lib.i686 libv4l.i686 zlib-ng-compat.i686 gstreamer1.i686 gstreamer1-plugins-base.i686 gstreamer1-plugins-good.i686 gstreamer1-plugins-bad-free.i686
 > ```
 > (GStreamer 32-bit cần cho video call — nếu thiếu, video call crash trong winegstreamer.
 > `gstreamer1-plugin-libav.i686` để decode H.264 cần RPM Fusion:
 > `sudo dnf install https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm` rồi `sudo dnf install gstreamer1-plugin-libav.i686`)
 > **Arch:**
 > ```bash
-> sudo pacman -S --needed lib32-glibc lib32-libx11 lib32-libxext lib32-freetype2 lib32-mesa lib32-libpulse lib32-zlib
+> sudo pacman -S --needed lib32-glibc lib32-libx11 lib32-libxext lib32-freetype2 lib32-mesa lib32-libpulse lib32-alsa-lib lib32-libv4l lib32-zlib lib32-gstreamer lib32-gst-plugins-base lib32-gst-plugins-good lib32-gst-libav
 > ```
 > (hoặc cài wine hệ thống — `apt install wine` / `dnf install wine` /
 > `pacman -S wine` — tự kéo đủ thư viện).
@@ -196,8 +196,16 @@ rm -rf /tmp/test-prefix
 
 - ✅ ZaloCall.exe chạy dưới Wine (wow64), kết nối đủ 2 kênh. Các bản đã test
   thật qua replay (init → makeCall → incall → success → sendSignal):
-  **11.14** (96MB/852MB), **8.6** (54MB/565MB — dùng làm mặc định tải tự
-  động), **8.0.1** (53MB/564MB), **7.22** (53MB/563MB)
+  **11.14** (96MB/852MB — bản khuyên dùng, video call đã xác minh thật),
+  **8.6** (54MB/565MB — nhẹ hơn nhưng video call crash `msvcp140._Throw_C_error`
+  thiếu hàm CRT khi gặp lỗi decode), **8.0.1**, **7.22**
+- ✅ **Video call hoạt động** trên Fedora (wine 11.14 + GStreamer 32-bit +
+  libv4l) — camera đôi khi cần ép format: `v4l2-ctl --set-fmt-video=width=640,height=480,pixelformat=MJPG`
+- ⚠️ **Share screen không hoạt động trên Wayland** — wine chỉ capture qua
+  X11/XWayland, và XWayland không nhìn thấy desktop Wayland. Cần đăng nhập
+  phiên X11 (GNOME on Xorg / Plasma X11) để dùng tính năng này. Đây là giới
+  hạn chung của phần mềm Windows qua Wine trên Wayland, không có cách xử lý
+  từ phía app.
 - ✅ `native-ready` → `init` → `makeCall` → `callState: incall`, `show success`,
   `sendSignal 401` — engine thực hiện cuộc gọi thật (voice + video signaling)
 - ✅ **Người dùng xác nhận cuộc gọi thoại hoạt động** trong app

--- a/zcall-bridge/README.md
+++ b/zcall-bridge/README.md
@@ -197,12 +197,43 @@ v4l2-ctl --set-fmt-video=width=640,height=480,pixelformat=MJPG
 
 (hết hiệu lực khi rút cắm camera)
 
+### Share screen trên Wayland (bridge)
+
+Trên Wayland, XWayland không nhìn thấy desktop nên ZaloCall (wine) chụp được
+màn hình đen. App có sẵn **bridge riêng**:
+
+1. Cài thành phần (một lần):
+   ```bash
+   # Fedora:  sudo dnf install xorg-x11-server-Xvfb xdotool python3-dbus
+   # Ubuntu:  sudo apt install xvfb xdotool python3-dbus
+   # Arch:    sudo pacman -S xorg-server-xvfb xdotool python-dbus
+   ```
+   (`streamproxy.so` được build sẵn vào app — không cần cài gì thêm.)
+2. Gọi video **hoàn toàn như bình thường** — giao diện cuộc gọi là cửa sổ
+   native trên desktop, không có gì thay đổi
+3. Bấm **Share screen** như thường → **hộp thoại xin quyền ghi màn hình
+   (portal chuẩn) tự hiện ra** → chọn màn hình → Cho phép → hình chia sẻ
+   được lấy từ màn hình Wayland thật qua bridge ✓
+
+Bridge chạy **Xvfb headless** làm màn hình render (`:99`): màn hình Wayland
+được đưa vào đó qua XDG ScreenCast portal + GStreamer. ZaloCall **vẫn chạy
+native trên màn hình thật**; `streamproxy.so` (shim LD_PRELOAD, build sẵn
+theo app) chặn đúng các lời gọi chụp màn hình của ZaloCall
+(`XGetImage`/`XShmGetImage`/`xcb_get_image` trên root) và **trả về nội dung
+từ `:99`** — nên phần còn lại của app (giao diện, âm thanh, video) không
+đổi, chỉ riêng hình ảnh chia sẻ đi qua bridge. Shim cũng **tự báo hiệu**
+(bằng file request) khi phát hiện lần chụp màn hình đầu tiên — app theo
+dõi và tự khởi động bridge, nên không cần thao tác nào thêm. Nếu người
+dùng từ chối hộp thoại quyền, app không hỏi lại trong 90 giây (bấm lại Share
+screen để thử lại). Bridge tự tắt khi thoát app.
+
+Trên **phiên X11**, share screen hoạt động trực tiếp — không cần bridge.
+
 ### Lưu ý giới hạn
 
 - Bản kron4ek **wow64** (thuần 64-bit) không chạy được ZaloCall — không dùng.
-- **Share screen chỉ hoạt động trên phiên X11** (GNOME on Xorg / Plasma X11);
-  trên Wayland, XWayland không nhìn thấy desktop nên màn hình chia sẻ trống —
-  giới hạn chung của Wine trên Wayland, không có cách xử lý từ phía app.
+- Công cụ xwaylandvideobridge của KDE chỉ chạy trên KDE Plasma (KWin); trên
+  GNOME dùng bridge tích hợp của app (mục trên).
 
 ### Ví dụ chạy với wine tự chọn
 
@@ -271,11 +302,12 @@ rm -rf /tmp/test-prefix
   thiếu hàm CRT khi gặp lỗi decode), **8.0.1**, **7.22**
 - ✅ **Video call hoạt động** trên Fedora (wine 11.14 + GStreamer 32-bit +
   libv4l) — camera đôi khi cần ép format: `v4l2-ctl --set-fmt-video=width=640,height=480,pixelformat=MJPG`
-- ⚠️ **Share screen không hoạt động trên Wayland** — wine chỉ capture qua
-  X11/XWayland, và XWayland không nhìn thấy desktop Wayland. Cần đăng nhập
-  phiên X11 (GNOME on Xorg / Plasma X11) để dùng tính năng này. Đây là giới
-  hạn chung của phần mềm Windows qua Wine trên Wayland, không có cách xử lý
-  từ phía app.
+- ✅ **Share screen trên Wayland** qua bridge tích hợp (XDG ScreenCast
+  portal → PipeWire → GStreamer → Xvfb headless `:99` → streamproxy shim
+  32-bit → ZaloCall) — **người dùng xác nhận share hoạt động** trên KDE
+  Wayland; ZaloCall chạy native, giao diện cuộc gọi không đổi; hộp thoại
+  quyền tự hiện khi bấm Share screen (shim báo hiệu qua file request)
+- ⚠️ Trên phiên X11 không cần bridge — share screen hoạt động trực tiếp.
 - ✅ `native-ready` → `init` → `makeCall` → `callState: incall`, `show success`,
   `sendSignal 401` — engine thực hiện cuộc gọi thật (voice + video signaling)
 - ✅ **Người dùng xác nhận cuộc gọi thoại hoạt động** trong app

--- a/zcall-bridge/pipebridge.c
+++ b/zcall-bridge/pipebridge.c
@@ -1,0 +1,154 @@
+/*
+ * pipebridge.c — tiny named-pipe <-> TCP pump for ZaloCall.exe under Wine.
+ *
+ * Build: i686-w64-mingw32-gcc pipebridge.c -lws2_32 -o pipebridge.exe
+ * Run (inside Wine): pipebridge.exe <tcpRecvPort> <tcpSendPort> [authToken]
+ *
+ * Creates the named pipes ZaloCall.exe connects to:
+ *   \\.\pipe\PipeZCallRecv  (helper -> main)   -> TCP 127.0.0.1:<tcpRecvPort>
+ *   \\.\pipe\PipeZCallSend  (main -> helper)   -> TCP 127.0.0.1:<tcpSendPort>
+ *
+ * Auth: when [authToken] is given, the token + '\n' is sent as the first
+ * line of every TCP connection; the main app drops connections that do not
+ * start with the token.
+ */
+#include <winsock2.h>
+#include <windows.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+    HANDLE pipe;
+    SOCKET sock;
+    int dir; /* 0 = pipe->sock, 1 = sock->pipe */
+} PumpArgs;
+
+static const char *g_token = NULL; /* NULL = no auth */
+
+static DWORD WINAPI pump(LPVOID arg) {
+    PumpArgs *a = (PumpArgs *)arg;
+    char buf[65536];
+    DWORD got;
+    int sent;
+
+    if (a->dir == 0) {
+        /* pipe -> socket */
+        while (ReadFile(a->pipe, buf, sizeof(buf), &got, NULL) && got > 0) {
+            sent = send(a->sock, buf, (int)got, 0);
+            if (sent <= 0) break;
+        }
+    } else {
+        /* socket -> pipe */
+        DWORD written;
+        while ((sent = recv(a->sock, buf, sizeof(buf), 0)) > 0) {
+            if (!WriteFile(a->pipe, buf, (DWORD)sent, &written, NULL)) break;
+        }
+    }
+    return 0;
+}
+
+static void bridge(const char *pipeName, unsigned short tcpPort, const char *label) {
+    HANDLE hPipe;
+    SOCKET sock;
+    struct sockaddr_in addr;
+    PumpArgs a1, a2;
+    HANDLE t1, t2;
+
+    for (;;) {
+        hPipe = CreateNamedPipeA(pipeName,
+            PIPE_ACCESS_DUPLEX,
+            PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT,
+            1, 65536, 65536, 0, NULL);
+        if (hPipe == INVALID_HANDLE_VALUE) {
+            fprintf(stderr, "[%s] CreateNamedPipe failed: %lu\n", label, GetLastError());
+            return;
+        }
+        fprintf(stderr, "[%s] pipe listening: %s\n", label, pipeName);
+
+        if (!ConnectNamedPipe(hPipe, NULL) &&
+            GetLastError() != ERROR_PIPE_CONNECTED) {
+            fprintf(stderr, "[%s] ConnectNamedPipe failed: %lu\n", label, GetLastError());
+            CloseHandle(hPipe);
+            Sleep(1000);
+            continue;
+        }
+        fprintf(stderr, "[%s] helper connected\n", label);
+
+        sock = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+        if (sock == INVALID_SOCKET) {
+            fprintf(stderr, "[%s] socket failed: %d\n", label, WSAGetLastError());
+            CloseHandle(hPipe);
+            Sleep(1000);
+            continue;
+        }
+        memset(&addr, 0, sizeof(addr));
+        addr.sin_family = AF_INET;
+        addr.sin_port = htons(tcpPort);
+        addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+        if (connect(sock, (struct sockaddr *)&addr, sizeof(addr)) != 0) {
+            fprintf(stderr, "[%s] tcp connect failed: %d\n", label, WSAGetLastError());
+            closesocket(sock);
+            CloseHandle(hPipe);
+            Sleep(1000);
+            continue;
+        }
+        fprintf(stderr, "[%s] tcp connected: %u\n", label, tcpPort);
+
+        if (g_token && g_token[0]) {
+            char line[256];
+            int n = snprintf(line, sizeof(line), "%s\n", g_token);
+            if (n > 0 && send(sock, line, (int)n, 0) <= 0) {
+                fprintf(stderr, "[%s] token send failed\n", label);
+                closesocket(sock);
+                DisconnectNamedPipe(hPipe);
+                CloseHandle(hPipe);
+                continue;
+            }
+        }
+
+        a1.pipe = hPipe; a1.sock = sock; a1.dir = 0;
+        a2.pipe = hPipe; a2.sock = sock; a2.dir = 1;
+        t1 = CreateThread(NULL, 0, pump, &a1, 0, NULL);
+        t2 = CreateThread(NULL, 0, pump, &a2, 0, NULL);
+        WaitForSingleObject(t1, INFINITE);
+        WaitForSingleObject(t2, INFINITE);
+
+        fprintf(stderr, "[%s] connection ended, waiting for reconnect\n", label);
+        closesocket(sock);
+        DisconnectNamedPipe(hPipe);
+        CloseHandle(hPipe);
+    }
+}
+
+typedef struct {
+    const char *pipeName;
+    unsigned short tcpPort;
+    const char *label;
+} BridgeArgs;
+
+static DWORD WINAPI bridgeThread(LPVOID arg) {
+    BridgeArgs *b = (BridgeArgs *)arg;
+    bridge(b->pipeName, b->tcpPort, b->label);
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    WSADATA wsa;
+    unsigned short recvPort = (argc > 1) ? (unsigned short)atoi(argv[1]) : 29631;
+    unsigned short sendPort = (argc > 2) ? (unsigned short)atoi(argv[2]) : 29632;
+
+    WSAStartup(MAKEWORD(2, 2), &wsa);
+    if (argc > 3 && argv[3][0]) g_token = argv[3];
+    fprintf(stderr, "[pipebridge] recv=%u send=%u auth=%s\n", recvPort, sendPort,
+            g_token ? "yes" : "no");
+
+    BridgeArgs r = { "\\\\.\\pipe\\PipeZCallRecv", recvPort, "RECV" };
+    BridgeArgs s = { "\\\\.\\pipe\\PipeZCallSend", sendPort, "SEND" };
+    CreateThread(NULL, 0, bridgeThread, &r, 0, NULL);
+    CreateThread(NULL, 0, bridgeThread, &s, 0, NULL);
+
+    /* keep the process alive */
+    for (;;) Sleep(60000);
+    return 0;
+}

--- a/zcall-bridge/pipebridge.c
+++ b/zcall-bridge/pipebridge.c
@@ -135,6 +135,14 @@ static DWORD WINAPI bridgeThread(LPVOID arg) {
 
 int main(int argc, char **argv) {
     WSADATA wsa;
+
+    /* Self-test used by the Linux app to verify this wine can run 32-bit
+       executables: pipebridge.exe --version prints and exits. */
+    if (argc > 1 && strcmp(argv[1], "--version") == 0) {
+        printf("pipebridge 1\n");
+        return 0;
+    }
+
     unsigned short recvPort = (argc > 1) ? (unsigned short)atoi(argv[1]) : 29631;
     unsigned short sendPort = (argc > 2) ? (unsigned short)atoi(argv[2]) : 29632;
 

--- a/zcall-bridge/pipebridge.c
+++ b/zcall-bridge/pipebridge.c
@@ -112,7 +112,11 @@ static void bridge(const char *pipeName, unsigned short tcpPort, const char *lab
         t1 = CreateThread(NULL, 0, pump, &a1, 0, NULL);
         t2 = CreateThread(NULL, 0, pump, &a2, 0, NULL);
         WaitForSingleObject(t1, INFINITE);
-        WaitForSingleObject(t2, INFINITE);
+        /* The pipe->socket pump exits when ZaloCall goes away. Unblock the
+           socket->pipe pump (it may be parked in recv) so the loop can
+           re-create the pipes and wait for the next ZaloCall instance. */
+        shutdown(sock, SD_BOTH);
+        WaitForSingleObject(t2, 5000);
 
         fprintf(stderr, "[%s] connection ended, waiting for reconnect\n", label);
         closesocket(sock);

--- a/zcall-bridge/screenbridge.py
+++ b/zcall-bridge/screenbridge.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""screenbridge.py — Wayland screen-share bridge for ZaloCall under Wine.
+
+Requests a screen stream through the XDG ScreenCast portal (this pops the
+compositor's permission/source dialog), receives the PipeWire fd, and hands
+it to gst-launch which renders the stream fullscreen into the Xvfb display
+given as argv[1] (e.g. ":99").
+
+Usage: python3 screenbridge.py :99 [app_id]
+
+Requires: python3-dbus, gst-launch-1.0 with pipewiresrc (plugins-bad) and
+ximagesink (plugins-base).
+"""
+
+import os
+import subprocess
+import sys
+import time
+
+import dbus
+import dbus.mainloop.glib
+from dbus.mainloop.glib import DBusGMainLoop
+
+DISPLAY2 = sys.argv[1] if len(sys.argv) > 1 else ":99"
+# KDE's portal backend rejects app ids without a matching .desktop file.
+APP_ID = sys.argv[2] if len(sys.argv) > 2 else "org.kde.konsole"
+
+
+def make_iface(bus, name, direct_backend=False):
+    portal = bus.get_object(name, "/org/freedesktop/portal/desktop")
+    iface_name = (
+        "org.freedesktop.impl.portal.ScreenCast"
+        if direct_backend
+        else "org.freedesktop.portal.ScreenCast"
+    )
+    return dbus.Interface(portal, iface_name)
+
+
+def run():
+    DBusGMainLoop(set_as_default=True)
+    bus = dbus.SessionBus()
+    from gi.repository import GLib
+
+    iface = make_iface(bus, "org.freedesktop.portal.Desktop")
+    direct_backend = False
+    token = "zalo_screenbridge_%d" % os.getpid()
+
+    state = {"phase": "session", "session": None, "node_id": None, "denied": False}
+
+    def on_response(response, results, message=None):
+        try:
+            if response != 0:
+                print("portal response %s, denying" % response, file=sys.stderr)
+                state["denied"] = True
+                state["loop"].quit()
+                return
+            if state["phase"] == "session":
+                for k, v in results.items():
+                    if str(k) == "session_handle":
+                        state["session"] = dbus.ObjectPath(str(v))
+                        state["phase"] = "sources"
+                        print("session handle: %s" % state["session"], file=sys.stderr)
+                        break
+            elif state["phase"] == "sources":
+                # user finished choosing sources (or the choice was implicit)
+                print("sources selected", file=sys.stderr)
+                state["phase"] = "start"
+            elif state["phase"] == "start":
+                for k, v in results.items():
+                    if str(k) == "streams":
+                        streams = v
+                        if not streams:
+                            print("no streams in result", file=sys.stderr)
+                            state["denied"] = True
+                            state["loop"].quit()
+                            return
+                        node_id, second = streams[0]
+                        # Portal >= 1.19: connect to the PipeWire node
+                        # directly (the fd is no longer passed around).
+                        state["node_id"] = int(node_id)
+                        print("got pipewire node %d" % state["node_id"], file=sys.stderr)
+                        state["loop"].quit()
+                        return
+        except Exception as e:  # noqa
+            print("response error: %s" % e, file=sys.stderr)
+            state["loop"].quit()
+
+    # Response signals are emitted from the request object paths, so listen
+    # at any path (impl backends use org.freedesktop.impl.portal.Request).
+    bus.add_signal_receiver(
+        on_response,
+        signal_name="Response",
+        dbus_interface="org.freedesktop.portal.Request",
+        message_keyword="message",
+    )
+    bus.add_signal_receiver(
+        on_response,
+        signal_name="Response",
+        dbus_interface="org.freedesktop.impl.portal.Request",
+        message_keyword="message",
+    )
+
+    loop = GLib.MainLoop()
+    state["loop"] = loop
+
+    def wait_phase(target, seconds):
+        ctx = GLib.MainContext.default()
+        waited = 0
+        while not state["denied"] and state["phase"] != target and waited < seconds * 50:
+            ctx.iteration(False)
+            time.sleep(0.02)
+            waited += 1
+        return state["phase"] == target
+
+    def create_session():
+        # session_handle_token is REQUIRED by portal >= 1.20 — missing it
+        # triggers an assertion crash in xdp-session.c.
+        iface.CreateSession(
+            {
+                "handle_token": token,
+                "session_handle_token": token + "_session",
+            }
+        )
+
+    try:
+        create_session()
+        if not wait_phase("sources", 15):
+            print("timed out waiting for session", file=sys.stderr)
+            sys.exit(1)
+    except Exception as e:
+        print("portal attempt failed: %s" % e, file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        iface.SelectSources(state["session"], {"types": dbus.UInt32(1), "multiple": False})
+        # The compositor dialog stays open until the user picks a source.
+        if not wait_phase("start", 120):
+            print("timed out or denied waiting for source selection", file=sys.stderr)
+            sys.exit(1)
+
+        iface.Start(state["session"], "", {"handle_token": token + "_start"})
+        loop.run()
+    except Exception as e:
+        print("start failed: %s" % e, file=sys.stderr)
+        sys.exit(1)
+
+    if state["denied"] or state.get("node_id") is None:
+        print("portal denied or no streams", file=sys.stderr)
+        sys.exit(1)
+
+    cmd = [
+        "gst-launch-1.0",
+        "pipewiresrc", "path=%d" % state["node_id"],
+        "!", "videoconvert",
+        "!", "ximagesink", "display=%s" % DISPLAY2, "sync=false",
+    ]
+    os.environ["DISPLAY"] = DISPLAY2
+    subprocess.run(cmd, check=False)
+
+
+if __name__ == "__main__":
+    run()

--- a/zcall-bridge/streamproxy.c
+++ b/zcall-bridge/streamproxy.c
@@ -1,0 +1,276 @@
+/*
+ * streamproxy.c — LD_PRELOAD shim that redirects the screen-capture reads of
+ * a wine app (ZaloCall) from its real X display to the bridge display (:99),
+ * where the Wayland screen is rendered by the screen bridge.
+ *
+ * ZaloCall runs natively on the real display (its call UI is a normal
+ * window), but when it captures the screen for "share screen" it reads the
+ * root window — which is black/unsupported on rootless XWayland. This shim
+ * intercepts the three capture APIs (libX11 XGetImage, XShmGetImage, xcb
+ * xcb_get_image) and, for root grabs, serves the same region from the
+ * bridge display instead. Everything else passes through untouched.
+ *
+ * The shim is inert when the bridge display is not reachable, so it can be
+ * preloaded unconditionally. When a capture happens and the bridge display
+ * is down, it touches ZCALL_PROXY_REQUEST — the plugin watches that file
+ * and starts the bridge (popping the compositor's permission dialog), so
+ * the user never has to prepare the bridge manually.
+ *
+ * Build (32-bit — ZaloCall is 32-bit, a 64-bit shim never intercepts):
+ *   gcc -m32 -shared -fPIC -O2 streamproxy.c -ldl -lX11 -lxcb -o streamproxy.so
+ * Debug: set ZCALL_PROXY_LOG=<file> to trace which API the app uses.
+ */
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <X11/Xlib.h>
+#include <X11/Xutil.h>
+#include <X11/extensions/XShm.h>
+#include <xcb/xcb.h>
+#include <xcb/xproto.h>
+
+static FILE *logf = NULL;
+
+static void plog(const char *fmt, ...) {
+    if (!logf) {
+        const char *p = getenv("ZCALL_PROXY_LOG");
+        if (!p) return;
+        logf = fopen(p, "a");
+        if (!logf) return;
+    }
+    va_list ap;
+    va_start(ap, fmt);
+    vfprintf(logf, fmt, ap);
+    va_end(ap);
+    fflush(logf);
+}
+
+/* ------------------------------------------------------------------ */
+/* lazy connections to the bridge display                              */
+/* ------------------------------------------------------------------ */
+
+static Display *src_dpy = NULL;
+static xcb_connection_t *src_c = NULL;
+static xcb_window_t src_root = 0;
+
+/* The app starts capturing (user clicked "share screen"): if the bridge
+ * display is not up, ask the plugin to start the bridge by touching the
+ * request file. The plugin watches it and pops the compositor's
+ * permission dialog. */
+static void signal_request(void) {
+    const char *p = getenv("ZCALL_PROXY_REQUEST");
+    if (!p) return;
+    FILE *f = fopen(p, "w");
+    if (f) fclose(f);
+}
+
+/* If the bridge display dies mid-capture, Xlib's default IO error handler
+ * would kill the whole app. Instead drop the cached connection (next grab
+ * re-opens or falls through) and chain anything else to the original
+ * handler. */
+static int (*orig_io_handler)(Display *) = NULL;
+
+static int src_io_handler(Display *d) {
+    if (d == src_dpy) {
+        plog("streamproxy: src connection broken, dropping cache\n");
+        src_dpy = NULL;
+        return 0;
+    }
+    if (orig_io_handler) return orig_io_handler(d);
+    return 1;
+}
+
+static Display *ensure_src_dpy(void) {
+    if (!src_dpy) {
+        const char *n = getenv("ZCALL_PROXY_SRC");
+        if (!n) n = ":99";
+        src_dpy = XOpenDisplay(n);
+        if (src_dpy) {
+            orig_io_handler = XSetIOErrorHandler(src_io_handler);
+            plog("streamproxy: libX11 src %s opened\n", n);
+        } else {
+            plog("streamproxy: cannot open src %s (not proxying)\n", n);
+            signal_request();
+        }
+    }
+    return src_dpy;
+}
+
+static xcb_connection_t *ensure_src_c(void) {
+    if (!src_c) {
+        const char *n = getenv("ZCALL_PROXY_SRC");
+        if (!n) n = ":99";
+        int scr = 0;
+        src_c = xcb_connect(n, &scr);
+        if (src_c && !xcb_connection_has_error(src_c)) {
+            xcb_screen_iterator_t it =
+                xcb_setup_roots_iterator(xcb_get_setup(src_c));
+            if (it.rem) src_root = it.data->root;
+            plog("streamproxy: xcb src %s opened\n", n);
+        } else {
+            if (src_c) xcb_disconnect(src_c);
+            src_c = NULL;
+            plog("streamproxy: cannot open xcb src %s\n", n);
+            signal_request();
+        }
+    }
+    return src_c;
+}
+
+/* ------------------------------------------------------------------ */
+/* libX11: XGetImage / XShmGetImage                                    */
+/* ------------------------------------------------------------------ */
+
+typedef XImage *(*XGetImage_fn)(Display *, Drawable, int, int, unsigned int,
+                                unsigned int, unsigned long, int);
+typedef Bool (*XShmGetImage_fn)(Display *, Drawable, XImage *, int, int,
+                                unsigned long);
+
+static XGetImage_fn real_XGetImage = NULL;
+static XShmGetImage_fn real_XShmGetImage = NULL;
+
+static int is_root(Display *dpy, Drawable d) {
+    return d == (Drawable)DefaultRootWindow(dpy);
+}
+
+XImage *XGetImage(Display *dpy, Drawable d, int x, int y, unsigned int w,
+                  unsigned int h, unsigned long plane_mask, int format) {
+    if (!real_XGetImage)
+        real_XGetImage = (XGetImage_fn)dlsym(RTLD_NEXT, "XGetImage");
+    if (ensure_src_dpy() && dpy != src_dpy && is_root(dpy, d)) {
+        XImage *im = real_XGetImage(src_dpy, (Drawable)DefaultRootWindow(src_dpy),
+                                    x, y, w, h, plane_mask, format);
+        plog("streamproxy: XGetImage root %ux%u+%d+%d -> %s\n", w, h, x, y,
+             im ? "proxied" : "src-failed, fell through");
+        if (im) return im;
+    }
+    return real_XGetImage(dpy, d, x, y, w, h, plane_mask, format);
+}
+
+Bool XShmGetImage(Display *dpy, Drawable d, XImage *image, int x, int y,
+                  unsigned long plane_mask) {
+    if (!real_XShmGetImage)
+        real_XShmGetImage = (XShmGetImage_fn)dlsym(RTLD_NEXT, "XShmGetImage");
+    if (ensure_src_dpy() && dpy != src_dpy && is_root(dpy, d) && image) {
+        XImage *im = real_XGetImage(src_dpy, (Drawable)DefaultRootWindow(src_dpy),
+                                    x, y, image->width, image->height,
+                                    plane_mask, ZPixmap);
+        if (im) {
+            size_t copy = im->bytes_per_line < image->bytes_per_line
+                              ? im->bytes_per_line
+                              : image->bytes_per_line;
+            for (unsigned int r = 0; r < (unsigned int)im->height; r++)
+                memcpy(image->data + (size_t)r * image->bytes_per_line,
+                       im->data + (size_t)r * im->bytes_per_line, copy);
+            XDestroyImage(im);
+            plog("streamproxy: XShmGetImage root %dx%d -> proxied\n",
+                 image->width, image->height);
+            return True;
+        }
+    }
+    return real_XShmGetImage(dpy, d, image, x, y, plane_mask);
+}
+
+/* ------------------------------------------------------------------ */
+/* xcb: xcb_get_image / xcb_get_image_reply (Qt QScreen::grabWindow)   */
+/* ------------------------------------------------------------------ */
+
+typedef xcb_get_image_cookie_t (*xcb_get_image_fn)(xcb_connection_t *, uint8_t,
+                                                   xcb_drawable_t, int16_t,
+                                                   int16_t, uint16_t, uint16_t,
+                                                   uint32_t);
+typedef xcb_get_image_reply_t *(*xcb_get_image_reply_fn)(
+    xcb_connection_t *, xcb_get_image_cookie_t, xcb_generic_error_t **);
+
+static xcb_get_image_fn real_xcb_get_image = NULL;
+static xcb_get_image_reply_fn real_xcb_get_image_reply = NULL;
+
+#define PROXY_MAP_SIZE 64
+static struct {
+    uint64_t seq;
+    int valid;
+    int16_t x, y;
+    uint16_t w, h;
+} proxy_map[PROXY_MAP_SIZE];
+
+static xcb_window_t conn_root(xcb_connection_t *c) {
+    xcb_screen_iterator_t it = xcb_setup_roots_iterator(xcb_get_setup(c));
+    return it.rem ? it.data->root : 0;
+}
+
+xcb_get_image_cookie_t xcb_get_image(xcb_connection_t *c, uint8_t format,
+                                     xcb_drawable_t drawable, int16_t x,
+                                     int16_t y, uint16_t width, uint16_t height,
+                                     uint32_t plane_mask) {
+    if (!real_xcb_get_image)
+        real_xcb_get_image = (xcb_get_image_fn)dlsym(RTLD_NEXT, "xcb_get_image");
+    xcb_get_image_cookie_t cookie =
+        real_xcb_get_image(c, format, drawable, x, y, width, height, plane_mask);
+    if (ensure_src_c() && c != src_c && drawable == conn_root(c)) {
+        unsigned int slot = cookie.sequence % PROXY_MAP_SIZE;
+        for (unsigned int i = 0; i < PROXY_MAP_SIZE; i++) {
+            unsigned int s = (slot + i) % PROXY_MAP_SIZE;
+            if (!proxy_map[s].valid) {
+                proxy_map[s].valid = 1;
+                proxy_map[s].seq = cookie.sequence;
+                proxy_map[s].x = x;
+                proxy_map[s].y = y;
+                proxy_map[s].w = width;
+                proxy_map[s].h = height;
+                plog("streamproxy: xcb_get_image root %ux%u+%d+%d queued\n",
+                     width, height, x, y);
+                break;
+            }
+        }
+    }
+    return cookie;
+}
+
+xcb_get_image_reply_t *xcb_get_image_reply(xcb_connection_t *c,
+                                           xcb_get_image_cookie_t cookie,
+                                           xcb_generic_error_t **e) {
+    if (!real_xcb_get_image_reply)
+        real_xcb_get_image_reply =
+            (xcb_get_image_reply_fn)dlsym(RTLD_NEXT, "xcb_get_image_reply");
+    unsigned int slot = cookie.sequence % PROXY_MAP_SIZE;
+    for (unsigned int i = 0; i < PROXY_MAP_SIZE; i++) {
+        unsigned int s = (slot + i) % PROXY_MAP_SIZE;
+        if (proxy_map[s].valid && proxy_map[s].seq == cookie.sequence) {
+            proxy_map[s].valid = 0;
+            /* swallow the real reply (BadMatch on rootless XWayland) */
+            xcb_generic_error_t *lerr = NULL;
+            xcb_get_image_reply_t *rr = real_xcb_get_image_reply(c, cookie, &lerr);
+            free(rr);
+            /* fetch the same region from the bridge display */
+            xcb_get_image_cookie_t c2 =
+                real_xcb_get_image(src_c, XCB_IMAGE_FORMAT_Z_PIXMAP, src_root,
+                                   proxy_map[s].x, proxy_map[s].y,
+                                   proxy_map[s].w, proxy_map[s].h, ~0);
+            xcb_get_image_reply_t *r2 = real_xcb_get_image_reply(src_c, c2, NULL);
+            if (r2) {
+                uint8_t *data = (uint8_t *)(r2 + 1);
+                size_t len = (size_t)r2->length * 4;
+                xcb_get_image_reply_t *out =
+                    malloc(sizeof(xcb_get_image_reply_t) + len);
+                memset(out, 0, sizeof(xcb_get_image_reply_t));
+                out->response_type = 1;
+                out->depth = r2->depth;
+                out->sequence = (uint16_t)cookie.sequence;
+                out->visual = r2->visual;
+                out->length = r2->length;
+                memcpy(out + 1, data, len);
+                free(r2);
+                plog("streamproxy: xcb root grab %ux%u -> proxied\n",
+                     proxy_map[s].w, proxy_map[s].h);
+                return out;
+            }
+            plog("streamproxy: xcb src grab failed\n");
+            return NULL;
+        }
+    }
+    return real_xcb_get_image_reply(c, cookie, e);
+}


### PR DESCRIPTION
Hiện tại zalo có vẻ sử dụng zcall-v2 và cái này nó lại hoạt động được ở wine (ZaloCall.exe), vậy nên ý tưởng là sẽ tạo 1 cái bridge để mượn luôn cái ZaloCall.exe này của bản windows và sẽ chạy chỉ riêng cái này ở wine:
Zalo app (Linux, native Electron)
    │ listen TCP 127.0.0.1:29631 + 29632 (mã hóa AES theo protocol gốc)
    │ spawn: wine pipebridge.exe <ports> <token>
    │ spawn: wine ZaloCall.exe \\.\pipe\PipeZCallRecv \\.\pipe\PipeZCallSend
    ▼ TCP loopback
  WINE (prefix riêng của app)
    pipebridge.exe (C, 252KB) — named pipes ⇄ TCP
    ZaloCall.exe — engine gọi thật (voice/video/group qua ZaviMeet.exe)

Mình đã test và hoạt động ổn cho cả call thường và call video, call nhóm cũng hoạt động ổn. Chỉ lấy thêm ZaloCall.exe và ZaviMeet.exe nên cũng nhẹ, appimage build ra 263MB so với 239MB lúc chưa thêm. Có thể cách này nó hơi lỏ nhưng mà ... chạy được, ít ra nó chỉ run mỗi cái service ZaloCall.exe của zalo chứ không run cả app. Mọi người có thể test thử xem có ổn không nhé.
